### PR TITLE
Rest editing tools

### DIFF
--- a/ly/rests.py
+++ b/ly/rests.py
@@ -29,6 +29,14 @@ from __future__ import unicode_literals
 import ly.document
 import ly.lex.lilypond
 
+def replace_rest(cursor, replace_token):
+    """Replace full rests (r) with optional token. """
+    source = ly.document.Source(cursor, True, tokens_with_position=True)
+    with cursor.document as d:
+        for token in source:
+            if isinstance(token, ly.lex.lilypond.Rest):
+                if token == 'r':
+                    d[token.pos:token.end] = replace_token
 
 def replace_fmrest(cursor, replace_token):
     """Replace full measusure rests (R) with optional token. """

--- a/ly/rests.py
+++ b/ly/rests.py
@@ -30,25 +30,25 @@ import ly.document
 import ly.lex.lilypond
 
 
-def fmrest2spacer(cursor):
-    """Replace full measusure rests (R) with spacer rests (s). """
+def replace_fmrest(cursor, replace_token):
+    """Replace full measusure rests (R) with optional token. """
     source = ly.document.Source(cursor, True, tokens_with_position=True)
     with cursor.document as d:
         for token in source:
             if isinstance(token, ly.lex.lilypond.Rest):
                 if token == 'R':
-                    d[token.pos:token.end] = 's'
+                    d[token.pos:token.end] = replace_token
 
-def spacer2fmrest(cursor):
-    """Replace spacer rests (s) with full measusure rests (R). """
+def replace_spacer(cursor, replace_token):
+    """Replace spacer rests (s) with optional token. """
     source = ly.document.Source(cursor, True, tokens_with_position=True)
     with cursor.document as d:
         for token in source:
             if isinstance(token, ly.lex.lilypond.Spacer):
-                d[token.pos:token.end] = 'R'
+                d[token.pos:token.end] = replace_token
 
-def restcomm2rest(cursor):
-    """Replace rests by rest command (\\rest) with plain rests (r). """
+def replace_restcomm(cursor, replace_token):
+    """Replace rests by rest command (\\rest) with optional token. """
 
     def get_comm_rests(source):
         """Catch all rests by rest command (\\rest) from source."""
@@ -72,8 +72,7 @@ def restcomm2rest(cursor):
             note = rt[0]
             space = rt[-2]
             comm = rt[-1]
-            d[note.pos:note.end] = 'r'
+            d[note.pos:note.end] = replace_token
             del d[space.pos:space.end]
             del d[comm.pos:comm.end]
 
-    

--- a/ly/rests.py
+++ b/ly/rests.py
@@ -46,3 +46,17 @@ def spacer2fmrest(cursor):
         for token in source:
             if isinstance(token, ly.lex.lilypond.Spacer):
                 d[token.pos:token.end] = 'R'
+
+def restcomm2rest(cursor):
+    """Replace rests by rest comman (\\rest) with plain rests (r). """
+    prev_note = None
+    source = ly.document.Source(cursor, True, tokens_with_position=True)
+    with cursor.document as d:
+        for token in source:
+            if isinstance(token, ly.lex.lilypond.Note):
+                prev_note = token
+                continue
+            if isinstance(token, ly.lex.lilypond.Command):
+                if token == '\\rest' and prev_note:
+                    d[prev_note.pos:prev_note.end] = 'r'
+                    del d[token.pos:token.end]

--- a/ly/rests.py
+++ b/ly/rests.py
@@ -1,0 +1,48 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2011 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Implementation of tools to edit rests of selected music.
+
+All functions except a ly.document.Cursor with the selected range.
+
+"""
+
+from __future__ import unicode_literals
+
+import ly.document
+import ly.lex.lilypond
+
+
+def fmrest2spacer(cursor):
+    """Replace full measusure rests (R) with spacer rests (s). """
+    source = ly.document.Source(cursor, True, tokens_with_position=True)
+    with cursor.document as d:
+        for token in source:
+            if isinstance(token, ly.lex.lilypond.Rest):
+                if token == 'R':
+                    d[token.pos:token.end] = 's'
+
+def spacer2fmrest(cursor):
+    """Replace spacer rests (s) with full measusure rests (R). """
+    source = ly.document.Source(cursor, True, tokens_with_position=True)
+    with cursor.document as d:
+        for token in source:
+            if isinstance(token, ly.lex.lilypond.Spacer):
+                d[token.pos:token.end] = 'R'


### PR DESCRIPTION
This is related to the rest conversion wish in issue #10.

The four functions facilitate the replacement of rests (`r`), full measure rests (`R`), spacer rests (`s`) and rests by rest command (`\rest`).

As said in the issue I'm thinking in particular about changes between full measure rests and spacer rests. But I hope these can also be useful for other stuff!