### PR TITLE
colorize: "Melt" also over space characters

### DIFF
--- a/ly/colorize.py
+++ b/ly/colorize.py
@@ -288,11 +288,15 @@ def melt_mapped_tokens(mapped_tokens):
     prev_tokens = []
     prev_style = None
     for t, s in mapped_tokens:
-        if s == prev_style:
+        if s == prev_style or t == ' ':
             prev_tokens.append(t)
         else:
             if prev_tokens:
-                yield ''.join(prev_tokens), prev_style
+                if prev_tokens[-1] == ' ':
+                    yield ''.join(prev_tokens[:-1]), prev_style
+                    yield ' ', None
+                else:
+                    yield ''.join(prev_tokens), prev_style
             prev_tokens = [t]
             prev_style = s
     if prev_tokens:

--- a/ly/colorize.py
+++ b/ly/colorize.py
@@ -288,7 +288,7 @@ def melt_mapped_tokens(mapped_tokens):
     prev_tokens = []
     prev_style = None
     for t, s in mapped_tokens:
-        if s == prev_style or t == ' ':
+        if s == prev_style or t.isspace():
             prev_tokens.append(t)
         else:
             if prev_tokens:


### PR DESCRIPTION
This commit improves the `melt_mapped_tokens` function so that
adjacent tokens are also melted when they are separated by spaces, e.g.
```
{
  c d e
}
```
will only return one `<span class="lilypond-pitch">` item instead of three.