### PR TITLE
add new context property supportNonIntegerFret

### DIFF
--- a/ly/data/_lilypond_data.py
+++ b/ly/data/_lilypond_data.py
@@ -1876,6 +1876,7 @@ contextproperties = [
     "strokeFingerOrientations",
     "subdivideBeams",
     "suggestAccidentals",
+    "supportNonIntegerFret",
     "systemStartDelimiter",
     "systemStartDelimiterHierarchy",
     "tabStaffLineLayoutFunction",
@@ -2607,5 +2608,4 @@ musicglyphs = [
     "z",
     "zero",
 ]
-
 


### PR DESCRIPTION
Added in LilyPond version 2.19.31:
http://git.savannah.gnu.org/cgit/lilypond.git/commit/?id=84ac019c437ea40b7b18ab46da1772f6db344a83