### PR TITLE
A variety of bug fixes and improvements for MusicXML output

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -536,6 +536,8 @@ class CreateMusicXML():
             repeatnode = etree.SubElement(barnode, "repeat", direction=repeat)
 
     def add_backup(self, duration):
+        if duration <= 0:
+            return
         backupnode = etree.SubElement(self.current_bar, "backup")
         durnode = etree.SubElement(backupnode, "duration")
         durnode.text = str(duration)

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -383,11 +383,17 @@ class CreateMusicXML():
 
     def add_time_modify(self, fraction):
         """Create time modification """
-        timemod_node = etree.SubElement(self.current_note, "time-modification")
+        index = get_tag_index(self.current_note, "accidental")
+        if index == -1:
+            index = get_tag_index(self.current_note, "dot")
+        if index == -1:
+            index = get_tag_index(self.current_note, "type")
+        timemod_node = etree.Element("time-modification")
         actual_notes = etree.SubElement(timemod_node, "actual-notes")
         actual_notes.text = str(fraction[0])
         norm_notes = etree.SubElement(timemod_node, "normal-notes")
         norm_notes.text = str(fraction[1])
+        self.current_note.insert(index + 1, timemod_node)
 
     def get_time_modify(self):
         """Check if time-modification node already exists."""

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -67,8 +67,9 @@ class CreateMusicXML():
 
     def create_title(self, title):
         """Create score title."""
-        mov_title = etree.SubElement(self.root, "movement-title")
+        mov_title = etree.Element("movement-title")
         mov_title.text = title
+        self.root.insert(0, mov_title)
 
     def create_score_info(self, tag, info, attr={}):
         """Create score info."""

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -565,6 +565,20 @@ class CreateMusicXML():
         dirtypenode = etree.SubElement(direction, "direction-type")
         dyn_node = etree.SubElement(dirtypenode, "wedge", type=wedge_type)
 
+    def add_dynamic_text(self, text):
+        """Add dynamic text."""
+        direction = etree.SubElement(self.current_bar, "direction", placement='below')
+        dirtypenode = etree.SubElement(direction, "direction-type")
+        dyn_node = etree.SubElement(dirtypenode, "words")
+        dyn_node.attrib['font-style'] = 'italic'
+        dyn_node.text = text
+
+    def add_dynamic_dashes(self, text):
+        """Add dynamics dashes."""
+        direction = etree.SubElement(self.current_bar, "direction", placement='below')
+        dirtypenode = etree.SubElement(direction, "direction-type")
+        dyn_node = etree.SubElement(dirtypenode, "dashes", type=text)
+
     def add_octave_shift(self, plac, octdir, size):
         """Add octave shift."""
         oct_dict = {"type": octdir, "size": str(size) }

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -551,8 +551,10 @@ class CreateMusicXML():
         staffnode.text = str(staff)
 
     def add_staves(self, staves):
-        stavesnode = etree.SubElement(self.bar_attr, "staves")
+        index = get_tag_index(self.bar_attr, "time")
+        stavesnode = etree.Element("staves")
         stavesnode.text = str(staves)
+        self.bar_attr.insert(index + 1, stavesnode)
 
     def add_chord(self):
         etree.SubElement(self.current_note, "chord")

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -361,7 +361,10 @@ class CreateMusicXML():
 
     def add_tie(self, tie_type):
         """Create node tie (used for sound of tie) """
-        etree.SubElement(self.current_note, "tie", type=tie_type)
+        # A tie must be directly after a duration
+        insert_at = get_tag_index(self.current_note, "duration") + 1
+        tie_element = etree.Element("tie", type=tie_type)
+        self.current_note.insert(insert_at, tie_element)
 
     def add_grace(self, slash):
         """Create grace node """
@@ -642,6 +645,17 @@ class MusicXML(object):
             # it is not a file object
             with open(file, 'wb') as f:
                 write(f)
+
+
+def get_tag_index(node, tag):
+    """Return the (first) index of tag in node.
+
+    If tag is not found, -1 is returned.
+    """
+    for i, elem in enumerate(list(node)):
+        if elem.tag == tag:
+            return i
+    return -1
 
 
 xml_decl_txt = """<?xml version="1.0" encoding="{encoding}"?>"""

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -71,6 +71,7 @@ class Mediator():
         self.lyric_syll = False
         self.lyric_nr = 1
         self.ongoing_wedge = False
+        self.ongoing_dashes = False
         self.octdiff = 0
         self.prev_tremolo = 8
         self.tupl_dur = 0
@@ -645,16 +646,30 @@ class Mediator():
 
     def new_dynamics(self, dynamics):
         hairpins = {'<': 'crescendo', '>': 'diminuendo'}
+        text_dyn = {'cresc': 'cresc.', 'decresc': 'descresc.',
+                    'dim': 'dim.'}
         if dynamics == '!':
-            self.current_note.set_dynamics_wedge('stop')
-            self.ongoing_wedge = False
+            if self.ongoing_wedge:
+                self.current_note.set_dynamics_wedge('stop')
+                self.ongoing_wedge = False
+            if self.ongoing_dashes:
+                self.current_note.set_dynamics_dashes('stop')
+                self.ongoing_dashes = False
         elif dynamics in hairpins:
             self.current_note.set_dynamics_wedge(hairpins[dynamics])
             self.ongoing_wedge = True
+        elif dynamics in text_dyn:
+            self.current_note.set_dynamics_text(text_dyn[dynamics])
+            self.current_note.set_dynamics_dashes('start', before=False)
+            self.ongoing_dashes = True
         elif self.ongoing_wedge:
             self.current_note.set_dynamics_wedge('stop')
             self.current_note.set_dynamics_mark(dynamics)
             self.ongoing_wedge = False
+        elif self.ongoing_dashes:
+            self.current_note.set_dynamics_dashes('stop')
+            self.current_note.set_dynamics_mark(dynamics)
+            self.ongoing_dashes = False
         else:
             self.current_note.set_dynamics_mark(dynamics)
 

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -672,7 +672,7 @@ class Mediator():
                 c.set_gliss(line, nr=n+1)
         else:
             self.current_note.set_gliss(line)
-        self.action_onnext.append(("end_gliss", line))
+        self.action_onnext.append(("end_gliss", (line, )))
 
     def end_gliss(self, note, line):
         if self.current_chord:

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -646,17 +646,17 @@ class Mediator():
     def new_dynamics(self, dynamics):
         hairpins = {'<': 'crescendo', '>': 'diminuendo'}
         if dynamics == '!':
-            self.current_note.set_dynamics(wedge='stop')
+            self.current_note.set_dynamics_wedge('stop')
             self.ongoing_wedge = False
         elif dynamics in hairpins:
-            self.current_note.set_dynamics(wedge=hairpins[dynamics])
+            self.current_note.set_dynamics_wedge(hairpins[dynamics])
             self.ongoing_wedge = True
         elif self.ongoing_wedge:
-            self.current_note.set_dynamics(wedge='stop')
-            self.current_note.set_dynamics(mark=dynamics)
+            self.current_note.set_dynamics_wedge('stop')
+            self.current_note.set_dynamics_mark(dynamics)
             self.ongoing_wedge = False
         else:
-            self.current_note.set_dynamics(mark=dynamics)
+            self.current_note.set_dynamics_mark(dynamics)
 
     def new_grace(self, slash=0):
         self.current_note.set_grace(slash)

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -164,6 +164,9 @@ class ParseSource():
             val = a.value().get_string()
             if not val:
                 self.schm_assignm = a.name()
+        elif isinstance(a.value(), ly.music.items.UserCommand):
+            # Don't know what to do with this:
+            return
         if self.look_behind(a, ly.music.items.With):
             if self.with_contxt in group_contexts:
                 self.mediator.set_by_property(a.name(), val, True)

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -154,6 +154,10 @@ class IterateXmlObjs():
                 self.musxml.add_dynamic_mark(d.sign)
             elif isinstance(d, DynamicsWedge):
                 self.musxml.add_dynamic_wedge(d.sign)
+            elif isinstance(d, DynamicsText):
+                self.musxml.add_dynamic_text(d.sign)
+            elif isinstance(d, DynamicsDashes):
+                self.musxml.add_dynamic_dashes(d.sign)
 
     def gener_xml_mus(self, obj):
         """Nodes generic for both notes and rests."""
@@ -528,6 +532,12 @@ class BarMus():
     def set_dynamics_wedge(self, sign, before=True):
         self.dynamic.append(DynamicsWedge(sign, before))
 
+    def set_dynamics_text(self, sign, before=True):
+        self.dynamic.append(DynamicsText(sign, before))
+
+    def set_dynamics_dashes(self, sign, before=True):
+        self.dynamic.append(DynamicsDashes(sign, before))
+
     def set_oct_shift(self, plac, octdir, size):
         self.oct_shift = OctaveShift(plac, octdir, size)
 
@@ -562,6 +572,16 @@ class DynamicsMark(Dynamics):
 
 class DynamicsWedge(Dynamics):
     """A dynamics wedge/hairpin."""
+    pass
+
+
+class DynamicsText(Dynamics):
+    """A dynamics text."""
+    pass
+
+
+class DynamicsDashes(Dynamics):
+    """Dynamics dashes."""
     pass
 
 

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -137,25 +137,23 @@ class IterateXmlObjs():
 
     def before_note(self, obj):
         """Xml-nodes before note."""
-        for d in obj.dynamic:
-            if d.before:
-                if isinstance(d, DynamicsMark):
-                    self.musxml.add_dynamic_mark(d.sign)
-                elif isinstance(d, DynamicsWedge):
-                    self.musxml.add_dynamic_wedge(d.sign)
+        self._add_dynamics([d for d in obj.dynamic if d.before])
         if obj.oct_shift and not obj.oct_shift.octdir == 'stop':
             self.musxml.add_octave_shift(obj.oct_shift.plac, obj.oct_shift.octdir, obj.oct_shift.size)
 
     def after_note(self, obj):
         """Xml-nodes after note."""
-        for d in obj.dynamic:
-            if not d.before:
-                if isinstance(d, DynamicsMark):
-                    self.musxml.add_dynamic_mark(d.sign)
-                elif isinstance(d, DynamicsWedge):
-                    self.musxml.add_dynamic_wedge(d.sign)
+        self._add_dynamics([d for d in obj.dynamic if not d.before])
         if obj.oct_shift and obj.oct_shift.octdir == 'stop':
             self.musxml.add_octave_shift(obj.oct_shift.plac, obj.oct_shift.octdir, obj.oct_shift.size)
+
+    def _add_dynamics(self, dyns):
+        """Add XML nodes for list of Dynamics objects."""
+        for d in dyns:
+            if isinstance(d, DynamicsMark):
+                self.musxml.add_dynamic_mark(d.sign)
+            elif isinstance(d, DynamicsWedge):
+                self.musxml.add_dynamic_wedge(d.sign)
 
     def gener_xml_mus(self, obj):
         """Nodes generic for both notes and rests."""

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -139,9 +139,9 @@ class IterateXmlObjs():
         """Xml-nodes before note."""
         for d in obj.dynamic:
             if d.before:
-                if d.is_mark:
+                if isinstance(d, DynamicsMark):
                     self.musxml.add_dynamic_mark(d.sign)
-                else:
+                elif isinstance(d, DynamicsWedge):
                     self.musxml.add_dynamic_wedge(d.sign)
         if obj.oct_shift and not obj.oct_shift.octdir == 'stop':
             self.musxml.add_octave_shift(obj.oct_shift.plac, obj.oct_shift.octdir, obj.oct_shift.size)
@@ -150,9 +150,9 @@ class IterateXmlObjs():
         """Xml-nodes after note."""
         for d in obj.dynamic:
             if not d.before:
-                if d.is_mark:
+                if isinstance(d, DynamicsMark):
                     self.musxml.add_dynamic_mark(d.sign)
-                else:
+                elif isinstance(d, DynamicsWedge):
                     self.musxml.add_dynamic_wedge(d.sign)
         if obj.oct_shift and obj.oct_shift.octdir == 'stop':
             self.musxml.add_octave_shift(obj.oct_shift.plac, obj.oct_shift.octdir, obj.oct_shift.size)
@@ -524,14 +524,11 @@ class BarMus():
     def add_other_notation(self, other):
         self.other_notation = other
 
-    def set_dynamics(self, mark=None, wedge=None, before=True):
-        if mark:
-            sign = mark
-            is_mark = True
-        if wedge:
-            sign = wedge
-            is_mark = False
-        self.dynamic.append(Dynamics(sign, before, is_mark))
+    def set_dynamics_mark(self, sign, before=True):
+        self.dynamic.append(DynamicsMark(sign, before))
+
+    def set_dynamics_wedge(self, sign, before=True):
+        self.dynamic.append(DynamicsWedge(sign, before))
 
     def set_oct_shift(self, plac, octdir, size):
         self.oct_shift = OctaveShift(plac, octdir, size)
@@ -555,10 +552,19 @@ class OctaveShift():
 
 class Dynamics():
     """Stores information about dynamics. """
-    def __init__(self, sign, before=True, is_mark=False, ):
+    def __init__(self, sign, before=True):
         self.before = before
-        self.is_mark = is_mark
         self.sign = sign
+
+
+class DynamicsMark(Dynamics):
+    """A dynamics mark."""
+    pass
+
+
+class DynamicsWedge(Dynamics):
+    """A dynamics wedge/hairpin."""
+    pass
 
 
 class Tuplet():

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -286,6 +286,11 @@ class ScorePartGroup():
     def set_bracket(self, bracket):
         self.bracket = bracket
 
+    def merge_voice(self, voice, override=False):
+        """Merge in a ScoreSection into all parts."""
+        for part in self.partlist:
+            part.merge_voice(voice, override)
+
 
 class ScoreSection():
     """ object to keep track of music section """


### PR DESCRIPTION
I have fixed a variety of bugs I encountered while using the MusicXML export. I've also improved the export of dynamics so that one can use textual dynamics like `\cresc` and `\dim`. Some of the changes tries to correct the order of XML nodes to satisfy the MusicXML standard. There may be other ways of ensuring correct ordering that are more robust than what I suggest. Open for suggestions.

I have minimal working/non-working examples that demonstrate the bugs I've fixed, which I can provide/commit if necessary. (Are there any unit/regression tests for python-ly at the moment?)