### PR TITLE
Make ly script independent from PYTHONPATH

### DIFF
--- a/bin/ly
+++ b/bin/ly
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
 import sys
+import os
+
+# Make ly independent of having PYTHONPATH set
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+python_ly_root = os.path.abspath(os.path.join(scriptdir, os.pardir))
+sys.path.append(python_ly_root)
+
 from ly.cli.main import main
 sys.exit(main())

--- a/bin/ly
+++ b/bin/ly
@@ -5,7 +5,8 @@ import os
 # Make ly independent of having PYTHONPATH set
 scriptdir = os.path.dirname(os.path.realpath(__file__))
 python_ly_root = os.path.abspath(os.path.join(scriptdir, os.pardir))
-sys.path.append(python_ly_root)
+if not python_ly_root in sys.path:
+    sys.path.append(python_ly_root)
 
 from ly.cli.main import main
 sys.exit(main())


### PR DESCRIPTION
Previously it was necessary to have the `ly` script in PATH
*and* the python-ly root directory in PYTHONPATH.

While requiring the PYTHONPATH setting for *importing* ly in
external Python programs is OK, there are use cases where only
the standalone script will have to be installed. For these uses
it is an unnecessary (and for non-Python-programmers confusing)
to have to set PYTHONPATH.