### PR TITLE
Add ly server (initial version)

### DIFF
--- a/bin/ly-server
+++ b/bin/ly-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import sys
+from ly.server.main import main
+sys.exit(main())

--- a/ly/cli/command.py
+++ b/ly/cli/command.py
@@ -241,7 +241,7 @@ class highlight(_export_command):
         w.inline_style = opts.inline_style
         w.stylesheet_ref = opts.stylesheet
         w.number_lines = opts.number_lines
-        w.title = cursor.document.filename
+        w.title = cursor.document.filename or ""
         w.encoding = opts.output_encoding or "utf-8"
         w.wrapper_tag = opts.wrapper_tag
         w.wrapper_attribute = opts.wrapper_attribute

--- a/ly/cli/main.py
+++ b/ly/cli/main.py
@@ -129,8 +129,23 @@ def parse_command_line():
         else:
             files.append(arg)
     from . import command
-    if not commands or isinstance(commands[-1], command._edit_command):
+    if not commands:
         commands.append(command.write())
+    
+    # check if we have export, edit or info commands
+    write = False
+    write_info = False
+    for c in commands:
+        if (isinstance(c, command._edit_command) or
+            isinstance(c, command._export_command)):
+                write = True
+        if isinstance(c, command._info_command):
+            write_info = True
+    if write_info:
+        commands.append(command.write_info())
+    if write:
+        commands.append(command.write())
+
     if not files:
         files.append('-')
     if opts.with_filename is None:
@@ -186,8 +201,11 @@ def main():
             sys.stderr.write('warning: skipping file "{0}":\n  {1}\n'.format(filename, err))
             exit_code = 1
             continue
-        cursor = ly.document.Cursor(doc)
+        data = {
+            'cursor': ly.document.Cursor(doc),
+            'info': []
+        }
         for c in commands:
-            c.run(options, cursor, output)
+            c.run(options, data)
     return exit_code
 

--- a/ly/cli/main.py
+++ b/ly/cli/main.py
@@ -109,7 +109,10 @@ def parse_command_line():
                 name, value = s.split('=', 1)
             except ValueError:
                 die("missing '=' in variable set")
-            opts.set_variable(name, value)
+            try:
+                opts.set_variable(name, value)
+            except Exception as e:
+                die(format(e))
         elif arg in ('-e', '--encoding'):
             opts.encoding = next_arg("missing encoding name")
         elif arg == '--output-encoding':
@@ -161,11 +164,14 @@ def parse_command(arg):
 def load(filename, encoding, mode):
     """Load a file, returning a ly.document.Document"""
     import ly.document
-    if filename == '-':
-        doc = ly.document.Document.load(sys.stdin.fileno(), encoding, mode)
-        doc.filename = '-'
-    else:
-        doc = ly.document.Document.load(filename, encoding, mode)
+    try:
+        if filename == '-':
+            doc = ly.document.Document.load(sys.stdin.fileno(), encoding, mode)
+            doc.filename = '-'
+        else:
+            doc = ly.document.Document.load(filename, encoding, mode)
+    except Exception as e:
+        die(format(e))
     return doc
 
 def main():

--- a/ly/cli/options.py
+++ b/ly/cli/options.py
@@ -1,0 +1,64 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Options configuring the commands' behaviour
+"""
+
+from __future__ import unicode_literals
+
+from . import setvar
+
+class Options(object):
+    """Store all the startup options and their defaults."""
+    def __init__(self):
+        self.mode = None
+        self.in_place = False
+        self.encoding = 'UTF-8'
+        self.output_encoding = None
+        self.output = None
+        self.replace_pattern = True
+        self.backup_suffix = '~'
+        self.with_filename = None
+        self.default_language = "nederlands"
+        
+        self.indent_width = 2
+        self.indent_tabs = False
+        self.tab_width = 8
+        
+        self.full_html = True
+        self.inline_style = False
+        self.stylesheet = None
+        self.number_lines = False
+        self.wrapper_tag = 'pre'
+        self.wrapper_attribute = 'class'
+        self.document_id = 'lilypond'
+        self.linenumbers_id = 'linenumbers'
+
+    def set_variable(self, name, value):
+        name = name.replace('-', '_')
+        try:
+            func = getattr(setvar, name)
+        except AttributeError:
+            raise AttributeError("unknown variable: {name}".format(name=name))
+        try:
+            value = func(value)
+        except ValueError as e:
+            raise ValueError(format(e))
+        setattr(self, name, value)    

--- a/ly/cli/output.py
+++ b/ly/cli/output.py
@@ -1,0 +1,86 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+An output object for handling processed documents
+"""
+
+import sys
+import os
+import io
+import contextlib
+
+class Output(object):
+    """Object living for a whole file/command operation, handling the output.
+    
+    When opening a file it has already opened earlier, the file is appended to
+    (like awk).
+    
+    """
+    def __init__(self):
+        self._seen_filenames = set()
+    
+    def get_filename(self, opts, filename):
+        """Queries the output attribute from the Options and returns it.
+        
+        If replace_pattern is True (by default) and the attribute contains a 
+        '*', it is replaced with the full path of the specified filename, 
+        but without extension. It the attribute contains a '?', it is 
+        replaced with the filename without path and extension.
+        
+        If '-' is returned, it denotes standard output.
+        
+        """
+        if not opts.output:
+            return '-'
+        elif opts.replace_pattern:
+            path, ext = os.path.splitext(filename)
+            directory, name = os.path.split(path)
+            return opts.output.replace('?', name).replace('*', path)
+        else:
+            return opts.output
+    
+    @contextlib.contextmanager
+    def file(self, opts, filename, encoding):
+        """Return a context manager for writing to.
+        
+        If you set encoding to "binary" or False, the file is opened in binary
+        mode and you should encode the data you write yourself.
+        
+        """
+        if not filename or filename == '-':
+            filename, mode = sys.stdout.fileno(), 'w'
+        #elif filename == '@http':
+            
+        else:
+            if filename not in self._seen_filenames:
+                self._seen_filenames.add(filename)
+                if opts.backup_suffix and os.path.exists(filename):
+                    shutil.copy(filename, filename + opts.backup_suffix)
+                mode = 'w'
+            else:
+                mode = 'a'
+        if encoding in (False, "binary"):
+            f = io.open(filename, mode + 'b')
+        else:
+            f = io.open(filename, mode, encoding=encoding)
+        try:
+            yield f
+        finally:
+            f.close()

--- a/ly/server/__init__.py
+++ b/ly/server/__init__.py
@@ -1,0 +1,23 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2008 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+A package implementing an HTTP server to process LilyPond input code.
+"""
+

--- a/ly/server/doc.py
+++ b/ly/server/doc.py
@@ -1,0 +1,250 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2015 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+# this module only contains a doc string, which is printed when using
+# ly -h .
+
+"""
+Usage::
+
+  ly-server [options]
+
+An HTTP server for manipulating LilyPond input code
+
+Options
+-------
+
+  -v, --version          show version number and exit
+  -h, --help             show this help text and exit
+  
+  Server Options
+  --------------
+  -p, --port PORT        port server listens to (default 5432)
+  -t, --timeout TIME     If set, server shuts down automatically
+                         after -t milliseconds of inactivity
+                         (useful in batch situations)
+                         NOT IMPLEMENTED YET!
+  
+  Command Options        Command options define defaults for the execution of
+  ---------------        commands triggered by HTTP requests. These options can
+                         be overridden by the individual HTTP request.
+  -e, --encoding ENC     (input) encoding (default UTF-8)
+  --output-encoding ENC  output encoding (default to input encoding)
+  -l, --language NAME    default pitch name language (default to "nederlands")
+  -d <variable=value>    set a variable (see below)
+
+
+HTTP Requests
+=============
+
+GET Requests
+------------
+
+Some GET requests will be implemented to retrieve values or change some
+server settings based on the URL path.
+
+
+POST Requests
+-------------
+
+The server accepts POST requests without (currently) making use of the URL path.
+As the request body it expects a single JSON string with the following elements:
+
+- 'commands' (mandatory): An array with one or more commands that are executed
+  subsequently. Each entry contains:
+    - 'command' (mandatory): A name for the command. It has to be one out of the
+      list of available commands below
+    - 'args' (optional): If a command requires arguments (e.g. the ``transpose``
+      command) they are given as a single string value.
+    - 'variables' (optional): A dictionary of variable assignments. Keys have to
+      be from the list below, and proper value types are checked.
+      If one or more variables are given they will be set *before* the command
+      is executed. A variable may be modified before the execution of the next
+      command but it is not reset automatically. Giving a variable with a value
+      of '' unsets the variable.
+- 'options' (optional): A dictionary of option assignments. Keys have to be from
+      the above list of Command Options, taking the long name without the leading
+      hyphens, e.g. { "encoding": "UTF-16" }.
+      If an option is given here it overrides the default option given on the
+      command line, but only for the current command.
+- 'data' (mandatory): A single string containing the LilyPond input document.
+
+The server will try to construct a series of commands from the request, and if
+anything is wrong with it send a "Bad Request" message with HTTP response code 400.
+If the commands execute successfully the response body will contain a JSON string
+with two elements:
+
+- 'info': 
+  A multiline string with the results of any info commands, one info per line
+- 'doc':
+  A string with the (usually) modified document
+
+Commands
+--------
+  
+Informative commands that return information and do not change the file:
+
+  ``mode``
+         print the mode (guessing if not given) of the document
+  
+  ``version``
+         print the LilyPond version, if set in the document
+
+  ``language``
+         print the pitch name language, if set in the document
+  
+Commands that return the processed input:
+
+  ``indent``
+         re-indent the file
+  
+  ``reformat``
+         reformat the file
+
+  ``translate <language>``
+         translate the pitch names to the language
+
+  ``transpose <from> <to>``
+         transpose the file like LilyPond would do, pitches
+         are given in the 'nederlands' language
+
+  ``abs2rel``
+         convert absolute music to relative
+
+  ``rel2abs``
+         convert relative music to absolute
+
+
+Commands that convert the input to another format:
+
+  ``musicxml``
+         convert to MusicXML (in development, far from complete)
+
+  ``highlight``
+         export the document as syntax colored HTML
+
+  ``hl``
+         alias for highlight
+
+
+Variables
+---------
+
+The following variables can be set to influence the behaviour of commands.
+If there is a default value, it is written between brackets:
+
+  ``mode``
+         mode of the file to read (default automatic) can be one
+         of: lilypond, scheme, latex, html, docbook, texinfo.
+  
+  ``encoding`` [UTF-8]
+         encoding to read (also set by -e argument)
+
+  ``default-language`` [nederlands]
+         the pitch names language to use by default, when not specified
+         otherwise in the document
+
+  ``output-encoding``
+         encoding to write (defaults to ``encoding``, also
+         set by the ``--output-encoding`` argument)
+
+  ``indent-tabs`` [``false``]
+         whether to use tabs for indent
+
+  ``indent-width`` [2]
+         how many spaces for each indent level (if not using tabs)
+
+  ``full-html`` [``True``]
+        if set to True a full document with syntax-highlighted HTML
+        will be exported, otherwise only the bare content wrapped in an
+        element configured by the ``wrapper-`` variables.        
+
+  ``stylesheet``
+         filename to reference as an external stylesheet for
+         syntax-highlighted HTML. This filename is literally used
+         in the ``<link rel="stylesheet">`` tag.
+
+  ``inline-style`` [``false``]
+         whether to use inline style attributes for syntax-highlighted HTML.
+         By default a css stylesheet is embedded.
+
+  ``number-lines`` [``false``]
+         whether to add line numbers when creating syntax-highlighted HTML.
+
+  ``wrapper-tag`` [``pre``]
+         which tag syntax highlighted HTML will be wrapped in. Possible values:
+         ``div``, ``pre``, ``id`` and ``code``
+
+  ``wrapper-attribute`` [``class``]
+        attribute used for the wrapper tag. Possible values: ``id`` and ``class``.
+
+  ``document-id`` [``lilypond``]
+        name applied to the wrapper-attribute.
+        If the three last options use their default settings
+        the highlighted HTML elements are wrapped in an element
+        ``<pre class="lilypond"></pre>``
+
+  ``linenumbers-id`` [``linenumbers``]
+        if linenumbers are exported this is the name used for the ``<td>`` elements
+
+
+
+Examples
+========
+
+Command line:
+-------------
+
+Basic invocation, listening on port 5432
+
+  ly-server
+
+Specifying port and a timeout
+
+  ly-server -p 4000 -t 5000
+  
+Requests:
+---------
+
+This is also processed as a demo request when the POST request body is empty:
+{
+    "commands": [
+        {
+            "command": "transpose",
+            "args": "c d"
+        },
+        {
+            "command": "highlight",
+            "variables": {
+                "full-html": "false"
+            }
+        },
+        {
+            "command": "mode"
+        }
+    ],
+    "options": {
+        "encoding": "UTF-16",
+        "language": "deutsch"
+    },
+    "data": "%No JSON data supplied. This is a test request.\n" +
+            "\\relative c" {\n  c4 ( d e )\n}"
+}
+
+"""

--- a/ly/server/handler.py
+++ b/ly/server/handler.py
@@ -1,0 +1,227 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+HTTP request handler
+"""
+
+from __future__ import unicode_literals
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+except ImportError:
+    from http.server import BaseHTTPRequestHandler
+
+import json
+import copy
+
+# Prototype (in JavaScript sense) from which each command copies its options
+default_opts = None
+
+class RequestHandler(BaseHTTPRequestHandler):
+    
+    def create_command(self, cmd):
+        """
+        Parse one command from the JSON data, plus optionally some commands to
+        set variables. Returns an array with command._command instances.
+        Raises exceptions upon faulty data.
+        """
+        from ly.cli import command
+        
+        result = []
+        
+        # if variables are given they are executed as intermediate commands
+        if 'variables' in cmd:
+            for v in cmd['variables']:
+                result.append(command.set_variable(
+                    v + "=" + cmd['variables'][v]))
+        
+        # try instantiating the command.
+        if not 'command' in cmd:
+            raise ValueError("Malformed JSON data in request body (missing 'command' field).\n" +
+                            "Object:\n" + json.dumps(cmd))
+        cmd_name = cmd['command'].replace('-', '_')
+        if not hasattr(command, cmd_name):
+            raise ValueError("unknown command: " + cmd_name)
+        
+        # add arguments to command if present.
+        args = cmd.get('args', '')
+        args = [args] if args else []
+        try:
+            result.append(getattr(command, cmd_name)(*args))
+        except TypeError as ae:
+            raise ValueError("Error creating command {cmd} with args {args}.\n{msg}".format(
+                            cmd = cmd_name,
+                            args = ", ".join(args),
+                            msg = str(ae)))
+        return result
+        
+
+    def process_options(self, opts):
+        """
+        Instantiate a copy of the default options and
+        update with the given opts
+        """
+        result = copy.deepcopy(default_opts)
+        
+        for opt in opts:
+            # handle special case where option name doesn't match CL interface
+            if opt == 'language':
+                result.set_variable('default-language', opts[opt])
+            else:
+                result.set_variable(opt, opts[opt])
+        
+        return result
+        
+        
+    def process_json_request(self, request):
+        """
+        Configure the action(s) to be taken, based on the JSON object.
+        Raise errors when the JSON object can't be properly understood.
+        Run the commands and return a string (from cursor.text() ).
+        """
+
+        # set up an Options object and
+        # override defaults with given options
+        opts = self.process_options(request.get('options', []))
+        
+        # set up commands
+        commands = []
+        for c in request['commands']:
+            commands.extend(self.create_command(c))        
+        
+        # create document from passed data
+        import ly.document
+        doc = ly.document.Document(request['data'], opts.mode)
+        doc.filename = ""
+
+        data = {
+            'cursor': ly.document.Cursor(doc),
+            'info': []
+        }
+        
+        # run commands, which modify data in-place
+        for c in commands:
+            c.run(opts, data)
+        
+        result = {
+            'info': '\n'.join(data['info']),
+            'doc': data['cursor'].text()
+        }
+        return json.dumps(result)
+
+        
+    def parse_json_request_body(self):
+        """
+        Returns the message body parsed to a dictionary
+        from JSON data. Raises 
+        - RuntimeWarnung when no JSON data is present
+        - ValueError when JSON parsing fails
+        """
+        
+        # The following dict is meant as a documentation 
+        # for constructing the request:
+        # 'commands' is mandatory and contains an array of command definitions:
+          # 'command' is mandatory
+          # 'args' is dependent on the command. If the commands requires it
+            # (such as e.g. transpose) it must be present
+          # 'variables' is optional.
+            # If variable declarations are present they are set before the 
+            # command is executed. They can be overridden with a subsequent
+            # command but are not forgotten automatically
+        # 'options' is optional and can override the command options given
+          # on the command line. It is written as a dict with the keys matching
+          # the property names of the Options() object (to be documented)
+        # 'data' is a string with the LilyPond input
+        
+        test_request = {
+            'commands': [
+                {
+                    'command': 'transpose',
+                    'args': 'c d'
+                },
+                {
+                    'command': 'highlights',
+                    'variables': {
+                        'full-html': 'false'
+                    }
+                },
+                {
+                    'command': 'mode'
+                }
+            ],
+            'options': {
+                'encoding': 'UTF-16',
+                'language': "deutsch"
+            },
+            'data': "%No JSON data supplied. This is a test request.\n" +
+                    "\\relative c' {\n  c4 ( d e )\n}"
+        }
+        
+        content_len = int(self.headers['content-length'])
+        
+        # Handle empty request
+        if content_len == 0:
+            #
+            # TODO: Discuss the desired behaviour here !!!
+            # For testing purposes it is definitely good to have,
+            # but for production work it may be more than confusing.
+            return test_request
+            raise RuntimeWarning("No JSON data in request body")
+        
+        request_body = self.rfile.read(content_len)
+        # Python2 has string, Python3 has bytestream
+        if not isinstance(request_body, str):
+            request_body = request_body.decode('utf-8')
+
+        try:
+            request = json.loads(request_body)
+        except Exception as e:
+            raise ValueError("Malformed JSON data in request body:\n" + str(e))
+
+        if not 'commands' in request:
+            raise ValueError("Malformed JSON request. Missing 'commands' property")
+        if not 'data' in request:
+            raise ValueError("Malformed JSON request. Missing 'data' property")
+
+        return request
+        
+    def do_POST(self):
+        """
+        A POST request is expected to contain the task to be executed 
+        as a JSON object in the request body.
+        The POST handler (currently) ignores the URL.
+        """
+        try:
+            request = self.parse_json_request_body()
+            result = self.process_json_request(request)
+        except Exception as e:
+            # TODO: disambiguate (ValueError, RuntimeWarning, others),
+            # use HTML templates
+            self.send_error(400)
+            # TODO: Is the encoding properly handled or do we have to consider our options?
+            # AND: THIS DOESNT' WORK IN PYTHON3!
+            self.wfile.write(str(e).encode())
+            self.end_headers()
+            return
+        
+        # Send successful response
+        self.send_header('Content-type', 'text/html')
+        # TODO: Is the encoding properly handled or do we have to consider our options?
+        self.wfile.write(result.encode())
+        self.end_headers()

--- a/ly/server/main.py
+++ b/ly/server/main.py
@@ -1,0 +1,153 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+The entry point for the 'ly-server' command.
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+try:
+    from BaseHTTPServer import HTTPServer
+except ImportError:
+    from http.server import HTTPServer
+
+import copy
+import sys
+
+from ly.cli.main import die, version
+import ly.cli.options
+from . import handler
+
+
+def usage():
+    """Print usage info."""
+    from . import doc
+    sys.stdout.write(doc.__doc__)
+
+def usage_short():
+    """Print short usage info."""
+    sys.stdout.write("""\
+Usage: ly-server [options]
+
+An HTTP server for manipulating LilyPond input code
+
+See ly -h for a full list of commands and options.
+""")
+
+
+class ServerOptions(object):
+    """
+    Options configuring the server itself, not the individual commands
+    """
+    
+    def __init__(self):
+        self.port = 5432
+        self.timeout = 0
+    
+
+def parse_command_line():
+    """Returns a two-tuple(server_opts, cmd_opts)
+    
+    server_opts is a ServerOptions instance configuring the server behaviour
+    cmd_opts is an Options instance with default options for future command
+    executions triggered by HTTP requests.
+    
+    Also performs error handling and may exit on certain circumstances.
+    
+    """
+    
+    if isinstance(sys.argv[0], type('')):
+        # python 3 - arguments are unicode strings
+        args = iter(sys.argv[1:])
+    else:
+        # python 2 - arguments are bytes, decode them
+        fsenc = sys.getfilesystemencoding() or 'latin1'
+        args = (a.decode(fsenc) for a in sys.argv[1:])
+    
+    server_opts = ServerOptions()
+    cmd_opts = ly.cli.options.Options()
+    
+    def next_arg(message):
+        """Get the next argument, if missing, die with message."""
+        try:
+            return next(args)
+        except StopIteration:
+            die(message)
+    
+    for arg in args:
+        if arg in ('-h', '--help'):
+            usage()
+            sys.exit(0)
+        elif arg in ('-v', '--version'):
+            version()
+            sys.exit(0)
+        
+        # Server Options
+        elif arg in ('-p', '--port'):
+            server_opts.port = int(next_arg("missing port number"))
+        elif arg in ('-t', '--timeout'):
+            server_opts.timeout = int(next_arg("missing timeout (in ms)"))
+            
+        # Command Options
+        elif arg in ('-e', '--encoding'):
+            cmd_opts.encoding = next_arg("missing encoding name")
+        elif arg == '--output-encoding':
+            cmd_opts.output_encoding = next_arg("missing output encoding name")
+        elif arg in ('-l', '--language'):
+            s = next_arg("missing language name")
+            cmd_opts.set_variable("default-language", s)
+        
+        # Command configuration Variables
+        elif arg == '-d':
+            s = next_arg("missing variable=value")
+            try:
+                name, value = s.split('=', 1)
+            except ValueError:
+                die("missing '=' in variable set")
+            cmd_opts.set_variable(name, value)
+        
+        elif arg.startswith('-'):
+            die('unknown option: ' + arg)
+    
+    return server_opts, cmd_opts
+
+
+def main():
+    server_opts, cmd_opts = parse_command_line()
+    
+    handler.default_opts = copy.deepcopy(cmd_opts)
+
+    import ly.document
+    exit_code = 0
+    
+    try:
+        server = HTTPServer(('', server_opts.port), handler.RequestHandler)
+        print("Welcome to the LilyPond syntax highlighter")
+        print("Listening on port {port}".format(port=server_opts.port))
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nKeyboard interrupt received. Shutting down server")
+        server.socket.close()
+        print("Successfully closed. Bye...")
+
+    
+    return exit_code
+


### PR DESCRIPTION
Closes #60

In its first version this server supports POST requests that trigger the ly commands just like the ly CLI script does.

There are some Python2/3 issues left, some discussion to be done and more functionality to be desired. In particular:

- Encoding problems with Python2/3
- Disambiguation of error reporting
- implementing the --timeout option (automatic shutdown)
- Add some GET routes for more interesting behaviour
  - /version (return ly version)
  - /stop (stop the server)
  - /timeout/N (modify the timeout)
  - etc?