### PR TITLE
(New) Initial version of ly-server, an HTTP server

### DIFF
--- a/bin/ly-server
+++ b/bin/ly-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import sys
+from ly.server.main import main
+sys.exit(main())

--- a/ly/server/__init__.py
+++ b/ly/server/__init__.py
@@ -1,0 +1,23 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2008 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+A package implementing an HTTP server to process LilyPond input code.
+"""
+

--- a/ly/server/command.py
+++ b/ly/server/command.py
@@ -1,0 +1,276 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+The commands that are available to the command line.
+"""
+
+from __future__ import unicode_literals
+
+import re
+import sys
+
+import ly
+
+known_commands = [
+    'mode',
+    'version',
+    'language',
+    'indent',
+    'reformat',
+    'translate',
+    'transpose',
+    'rel2abs',
+    'abs2rel',
+    'musicxml',
+    'highlight'
+]
+
+class _command(object):
+    """Base class for commands.
+
+    If the __init__() fails with TypeError or ValueError, the command is
+    considered invalid and an error message will be written to the console
+    in the parse_command() function in main.py.
+
+    By default, __init__() expects no arguments. If your command does accept
+    arguments, they are provided in a single argument that you should parse
+    yourself.
+
+    """
+    def __init__(self):
+        pass
+
+    def run(self, opts, data):
+        pass
+
+
+class set_variable(_command):
+    """set a configuration variable to a value"""
+    def __init__(self, arg):
+        self.name, self.value = arg.split('=', 1)
+
+    def run(self, opts, data):
+        opts.set_variable(self.name, self.value)
+
+
+#################################
+### Base classes for commands ###
+#################################
+
+# The command classes have a run() method that serves as a common structure
+# for each command type.  From within run() a function is called to perform
+# the actual, command-specific funcionality.
+# The run() method also takes care of updating the data object with the correct
+# nesting structure and metadata.
+class _info_command(_command):
+    """
+    Base class for commands that retrieve some info about the document.
+    The result is appended to the data['info'] array as a dict with 'command'
+    and 'info' fields.
+    """
+    def run(self, opts, data):
+        import ly.docinfo
+        info = ly.docinfo.DocInfo(data['doc']['content'].document)
+        text = self.get_info(info)
+        data['info'].append({
+            'command': self.__class__.__name__,
+            'info': text or ""
+        })
+
+    def get_info(self, info):
+        """
+        Should return the desired information from the docinfo object.
+        """
+        raise NotImplementedError()
+
+
+class _edit_command(_command):
+    """
+    Base class for commands that modify the input.
+    The modifications overwrite the content of data['doc']['content'], so a
+    subsequent edit commands builds on the modified content. The command name is
+    added to the data['doc']['commands'] dict so it is possible to retrace which
+    commands have been applied to the final result.
+    """
+    def run(self, opts, data):
+        self.edit(opts, data['doc']['content'])
+        data['doc']['commands'].append(self.__class__.__name__)
+    
+    def edit(self, opts, cursor):
+        """Should edit the cursor in-place."""
+        raise NotImplementedError()
+
+
+class _export_command(_command):
+    """
+    Base class for commands that convert the input to another format.
+    For each command an entry will be appended to data['exports'] field of the
+    'data' dict, leaving data['doc'] untouched. Each entry in data['exports']
+    has a ['doc'] and a ['command'] field, allowing the client to identify the
+    
+    """
+    def run(self, opts, data):
+        export = self.export(opts, data['doc']['content'], data['exports'])
+        data['exports'].append({
+            'command': self.__class__.__name__,
+            'doc': export
+        })
+    
+    def export(self, opts, cursor, exports):
+        """Should return the converted document as string."""
+        raise NotImplementedError()
+
+
+#####################
+### Info commands ###
+#####################
+
+class mode(_info_command):
+    """retrieve mode from document"""
+    def get_info(self, info):
+        return info.mode()
+
+
+class version(_info_command):
+    """retrieve version from document"""
+    def get_info(self, info):
+        return info.version_string()
+
+
+class language(_info_command):
+    """retrieve language from document"""
+    def get_info(self, info):
+        return info.language()
+
+
+#####################
+### Edit commands ###
+#####################
+
+class indent(_edit_command):
+    """run the indenter"""
+    def indenter(self, opts):
+        """Get a ly.indent.Indenter initialized with our options."""
+        import ly.indent
+        i = ly.indent.Indenter()
+        i.indent_tabs = opts.indent_tabs
+        i.indent_width = opts.indent_width
+        return i
+    
+    def edit(self, opts, cursor):
+        self.indenter(opts).indent(cursor)
+
+
+class reformat(indent):
+    """reformat the document"""
+    def edit(self, opts, cursor):
+        import ly.reformat
+        ly.reformat.reformat(cursor, self.indenter(opts))
+
+
+class translate(_edit_command):
+    """translate pitch names"""
+    def __init__(self, language):
+        if language not in ly.pitch.pitchInfo:
+            raise ValueError()
+        self.language = language
+    
+    def edit(self, opts, cursor):
+        import ly.pitch.translate
+        try:
+            changed = ly.pitch.translate.translate(cursor, self.language, opts.default_language)
+        except ly.pitch.PitchNameNotAvailable as pna:
+            raise ValueError(format(pna))
+        if not changed:
+            version = ly.docinfo.DocInfo(cursor.document).version()
+            ly.pitch.translate.insert_language(cursor.document, self.language, version)
+    
+
+class transpose(_edit_command):
+    """transpose music"""
+    def __init__(self, arg):
+        import re
+        result = []
+        for pitch, octave in re.findall(r"([a-z]+)([,']*)", arg):
+            r = ly.pitch.pitchReader("nederlands")(pitch)
+            if r:
+                result.append(ly.pitch.Pitch(*r, octave=ly.pitch.octaveToNum(octave)))
+        self.from_pitch, self.to_pitch = result
+
+    def edit(self, opts, cursor):
+        import ly.pitch.transpose
+        transposer = ly.pitch.transpose.Transposer(self.from_pitch, self.to_pitch)
+        try:
+            ly.pitch.transpose.transpose(cursor, transposer, opts.default_language)
+        except ly.pitch.PitchNameNotAvailable as pna:
+            language = ly.docinfo.DocInfo(cursor.document).language() or opts.default_language
+            raise ValueError(format(pna))
+
+
+class rel2abs(_edit_command):
+    """convert relative music to absolute"""
+    def edit(self, opts, cursor):
+        import ly.pitch.rel2abs
+        ly.pitch.rel2abs.rel2abs(cursor, opts.default_language)
+
+
+class abs2rel(_edit_command):
+    """convert absolute music to relative"""
+    def edit(self, opts, cursor):
+        import ly.pitch.abs2rel
+        ly.pitch.abs2rel.abs2rel(cursor, opts.default_language)
+
+
+#######################
+### Export commands ###
+#######################
+
+class musicxml(_export_command):
+    """convert source to MusicXML"""
+    def export(self, opts, cursor, exports):
+        import ly.musicxml
+        writer = ly.musicxml.writer()
+        writer.parse_document(cursor.document)
+        #TODO!!!
+        # In Python3 this incorrectly escapes the \n characters,
+        # but leaving out the str() conversion returns a Bytes object,
+        # which will in turn trigger an "object is not JSON serializable" error
+        return str(writer.musicxml().tostring())
+
+
+class highlight(_export_command):
+    """convert source to syntax colored HTML."""
+    def export(self, opts, cursor, exports):
+        import ly.colorize
+        w = ly.colorize.HtmlWriter()
+    
+        # set configuration options
+        w.full_html = opts.full_html
+        w.inline_style = opts.inline_style
+        w.stylesheet_ref = opts.stylesheet
+        w.number_lines = opts.number_lines
+        w.title = cursor.document.filename
+        w.encoding = opts.output_encoding or "utf-8"
+        w.wrapper_tag = opts.wrapper_tag
+        w.wrapper_attribute = opts.wrapper_attribute
+        w.document_id = opts.document_id
+        w.linenumbers_id = opts.linenumbers_id
+
+        return w.html(cursor)

--- a/ly/server/doc.py
+++ b/ly/server/doc.py
@@ -1,0 +1,274 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2015 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+# this module only contains a doc string, which is printed when using
+# ly -h .
+
+"""
+Usage::
+
+  ly-server [options]
+
+An HTTP server for manipulating LilyPond input code
+
+Options
+-------
+
+  -v, --version          show version number and exit
+  -h, --help             show this help text and exit
+  
+  Server Options
+  --------------
+  -p, --port PORT        port server listens to (default 5432)
+  -t, --timeout TIME     If set, server shuts down automatically
+                         after -t milliseconds of inactivity
+                         (useful in batch situations)
+                         NOT IMPLEMENTED YET!
+  
+  Command Options        Command options define defaults for the execution of
+  ---------------        commands triggered by HTTP requests. These options can
+                         be overridden by the individual HTTP request.
+  -e, --encoding ENC     (input) encoding (default UTF-8)
+  --output-encoding ENC  output encoding (default to input encoding)
+  -l, --language NAME    default pitch name language (default to "nederlands")
+  -d <variable=value>    set a variable (see below)
+
+
+HTTP Requests
+=============
+
+GET Requests
+------------
+
+Some GET requests will be implemented later to retrieve values
+or change some server settings based on the URL path.
+
+
+POST Requests
+-------------
+
+The server accepts POST requests without (currently) making use of the URL path.
+As the request body it expects a single JSON string with the following elements:
+
+- 'commands' (mandatory): 
+  An array with one or more commands to be executed subsequently. 
+  Each entry contains:
+    - 'command' (mandatory): 
+      A name for the command. It has to be one out of the list of available
+      commands below.
+    - 'args' (optional):
+      If a command requires arguments (e.g. the ``transpose`` command)
+      they are given as a single string value.
+    - 'variables' (optional): 
+      A dictionary of variable assignments. Keys have to be from the list below,
+      and proper value types are checked. If one or more variables are given
+      they will be set *before* the command is executed. A variable may be
+      modified again before the execution of the next command but it is not
+      reset automatically. Giving a variable with a value of '' unsets the
+      variable.
+- 'options' (optional): 
+   A dictionary of option assignments. Keys have to be from the above list of
+   Command Options, taking the long name without the leading hyphens, 
+   e.g. { "encoding": "UTF-16" }.
+   If an option is given here it overrides the default option given on the
+   command line, but only for the current command.
+- 'data' (mandatory): A single string containing the LilyPond input document.
+
+The server will try to construct a series of commands from the request, and if
+anything is wrong with it send a "Bad Request" message with HTTP response code 400.
+If the commands execute successfully the response body will contain a serialized
+JSON object with the following elements:
+
+- 'info': 
+  An array of entries with the result of "info" commands (see below).
+  Each entry has a ``command`` and an ``info`` field.
+- 'doc':
+  A dictionary with two fields:
+  - 'content':
+    A string with the content of the document with all "edit" commands applied
+    consecutively. (If no edit commands have been specified this contains the
+    original input.
+  - 'commands':
+    An array with the names of the commands that have been applied.
+- 'exports'
+  An array with entries for each applied "export" command.
+  Each entry has the following fields:
+  - 'doc'
+    A string with the content of the converted/exported document
+  - 'command'
+    The name of the applied command 
+
+Commands
+--------
+
+There are three types of commands whose results are handled independently:
+- "info" commands retrive metadata from the input document
+- "edit" commands modify the document, subsequent edit commands cascade the
+  modifications
+- "export" commands that convert the input to another format.
+  Subsequent commands are not affected by the result of export commands.
+
+  
+Informative commands that return information and do not change the file:
+
+  ``mode``
+         print the mode (guessing if not given) of the document
+  
+  ``version``
+         print the LilyPond version, if set in the document
+
+  ``language``
+         print the pitch name language, if set in the document
+  
+Commands that return the processed input:
+
+  ``indent``
+         re-indent the file
+  
+  ``reformat``
+         reformat the file
+
+  ``translate <language>``
+         translate the pitch names to the language
+
+  ``transpose <from> <to>``
+         transpose the file like LilyPond would do, pitches
+         are given in the 'nederlands' language
+
+  ``abs2rel``
+         convert absolute music to relative
+
+  ``rel2abs``
+         convert relative music to absolute
+
+
+Commands that convert the input to another format:
+
+  ``musicxml``
+         convert to MusicXML (in development, far from complete)
+
+  ``highlight``
+         export the document as syntax colored HTML
+
+
+
+Variables
+---------
+
+The following variables can be set to influence the behaviour of commands.
+If there is a default value, it is written between brackets:
+
+  ``mode``
+         mode of the file to read (default automatic) can be one
+         of: lilypond, scheme, latex, html, docbook, texinfo.
+  
+  ``encoding`` [UTF-8]
+         encoding to read (also set by -e argument)
+
+  ``default-language`` [nederlands]
+         the pitch names language to use by default, when not specified
+         otherwise in the document
+
+  ``output-encoding``
+         encoding to write (defaults to ``encoding``, also
+         set by the ``--output-encoding`` argument)
+
+  ``indent-tabs`` [``false``]
+         whether to use tabs for indent
+
+  ``indent-width`` [2]
+         how many spaces for each indent level (if not using tabs)
+
+  ``full-html`` [``True``]
+        if set to True a full document with syntax-highlighted HTML
+        will be exported, otherwise only the bare content wrapped in an
+        element configured by the ``wrapper-`` variables.        
+
+  ``stylesheet``
+         filename to reference as an external stylesheet for
+         syntax-highlighted HTML. This filename is literally used
+         in the ``<link rel="stylesheet">`` tag.
+
+  ``inline-style`` [``false``]
+         whether to use inline style attributes for syntax-highlighted HTML.
+         By default a css stylesheet is embedded.
+
+  ``number-lines`` [``false``]
+         whether to add line numbers when creating syntax-highlighted HTML.
+
+  ``wrapper-tag`` [``pre``]
+         which tag syntax highlighted HTML will be wrapped in. Possible values:
+         ``div``, ``pre``, ``id`` and ``code``
+
+  ``wrapper-attribute`` [``class``]
+        attribute used for the wrapper tag. Possible values: ``id`` and ``class``.
+
+  ``document-id`` [``lilypond``]
+        name applied to the wrapper-attribute.
+        If the three last options use their default settings
+        the highlighted HTML elements are wrapped in an element
+        ``<pre class="lilypond"></pre>``
+
+  ``linenumbers-id`` [``linenumbers``]
+        if linenumbers are exported this is the name used for the ``<td>`` elements
+
+
+
+Examples
+========
+
+Command line:
+-------------
+
+Basic invocation, listening on port 5432
+
+  ly-server
+
+Specifying port and a timeout
+
+  ly-server -p 4000 -t 5000
+  
+Requests:
+---------
+
+This is also processed as a demo request when the POST request body is empty:
+{
+    'commands': [
+        {
+            'command': 'transpose',
+            'args': 'c d'
+        },
+        { 'command': 'reformat' },
+        {
+            'command': 'highlight',
+            'variables': { 'full-html': 'false' }
+        },
+        { 'command': 'musicxml' },
+        { 'command': 'mode' },
+        { 'command': 'version' }
+    ],
+    'options': {
+        'encoding': 'UTF-16',
+        'language': "deutsch"
+    },
+    'data': "%No JSON data supplied. This is a test request.\n" +
+            "\\relative c' {\nc4 ( d e )\n}"
+}
+
+"""

--- a/ly/server/handler.py
+++ b/ly/server/handler.py
@@ -180,7 +180,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
         
         # Send successful response
+        self.send_response(200)
         self.send_header('Content-type', 'application/json')
-        # TODO: Is the encoding properly handled or do we have to consider our options?
-        self.wfile.write(json.dumps(result).encode())
         self.end_headers()
+        res_body = json.dumps(result)
+        if isinstance(res_body, str):
+            res_body = res_body.encode()
+        self.wfile.write(res_body)

--- a/ly/server/handler.py
+++ b/ly/server/handler.py
@@ -1,0 +1,186 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+HTTP request handler
+"""
+
+from __future__ import unicode_literals
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+except ImportError:
+    from http.server import BaseHTTPRequestHandler
+
+import json
+import copy
+
+# Prototype (in JavaScript sense) from which each command copies its options
+default_opts = None
+
+class RequestHandler(BaseHTTPRequestHandler):
+    
+    def create_command(self, cmd):
+        """
+        Parse one command from the JSON data, plus optionally some commands to
+        set variables. Returns an array with command._command instances.
+        Raises exceptions upon faulty data.
+        """
+        from . import command
+        
+        result = []
+        
+        # set variables before executing the command
+        if 'variables' in cmd:
+            for v in cmd['variables']:
+                result.append(command.set_variable(
+                    v + "=" + cmd['variables'][v]))
+        
+        # instantiate the command.
+        if not 'command' in cmd:
+            raise ValueError("Malformed JSON data in request body (missing 'command' field).\n" +
+                            "Object:\n" + json.dumps(cmd))
+        cmd_name = cmd['command'].replace('-', '_')
+        if not cmd_name in command.known_commands:
+            raise ValueError("unknown command: " + cmd_name)
+        
+        # add arguments to command if present.
+        args = cmd.get('args', '')
+        args = [args] if args else []
+        try:
+            result.append(getattr(command, cmd_name)(*args))
+        except TypeError as ae:
+            raise ValueError("Error creating command {cmd} with args {args}.\n{msg}".format(
+                            cmd = cmd_name,
+                            args = ", ".join(args),
+                            msg = str(ae)))
+        return result
+        
+
+    def process_options(self, opts):
+        """
+        Instantiate a copy of the default options and
+        update with the given opts
+        """
+        result = copy.deepcopy(default_opts)
+        for opt in opts:
+            # handle special case where option name doesn't match CL interface
+            if opt == 'language':
+                result.set_variable('default-language', opts[opt])
+            else:
+                result.set_variable(opt, opts[opt])
+        return result
+        
+        
+    def process_json_request(self, request):
+        """
+        Configure the action(s) to be taken, based on the JSON object.
+        Raise errors when the JSON object can't be properly understood.
+        Run the commands and return a string (from cursor.text() ).
+        """
+
+        # set up an Options object and
+        # override defaults with given options
+        opts = self.process_options(request.get('options', []))
+        
+        # set up commands
+        commands = []
+        for c in request['commands']:
+            commands.extend(self.create_command(c))        
+        
+        # create document from passed data
+        import ly.document
+        doc = ly.document.Document(request['data'], opts.mode)
+        doc.filename = ""
+
+        # data structure for the results
+        data = {
+            'doc': {
+                'commands': [],
+                'content': ly.document.Cursor(doc)
+            },
+            'info': [],
+            'exports': []
+        }
+        
+        # run commands, which modify data in-place
+        for c in commands:
+            c.run(opts, data)
+        
+        data['doc']['content'] = data['doc']['content'].text()
+        return data
+
+        
+    def read_json_request(self):
+        """
+        Returns the message body parsed to a dictionary
+        from JSON data. Raises 
+        - RuntimeWarning when no JSON data is present
+        - ValueError when JSON parsing fails
+        """
+        
+        content_len = int(self.headers['content-length'])
+        if content_len == 0:
+            #TODO: When testing is over remove (or comment out)
+            # the following two lines and raise the exception instead.
+            from . import testjson
+            return testjson.test_request
+            raise RuntimeWarning("No JSON data in request body")
+        
+        req_body = self.rfile.read(content_len)
+        # Python2 has string, Python3 has bytestream
+        if not isinstance(req_body, str):
+            req_body = req_body.decode('utf-8')
+
+        # parse body, initial validation
+        try:
+            request = json.loads(req_body)
+        except Exception as e:
+            raise ValueError("Malformed JSON data in request body:\n" + str(e))
+        if not 'commands' in request:
+            raise ValueError("Malformed JSON request. Missing 'commands' property")
+        if not 'data' in request:
+            raise ValueError("Malformed JSON request. Missing 'data' property")
+        return request
+
+
+    
+    ########################
+    ### Request handlers ###
+    ########################
+
+    def do_POST(self):
+        """
+        A POST request is expected to contain the task to be executed 
+        as a JSON object in the request body.
+        The POST handler (currently) ignores the URL.
+        """
+        try:
+            request = self.read_json_request()
+            result = self.process_json_request(request)
+        except Exception as e:
+            # TODO: should we disambiguate (ValueError, RuntimeWarning, others)?
+            # use HTML templates
+            self.send_error(400, format(e))
+            return
+        
+        # Send successful response
+        self.send_header('Content-type', 'application/json')
+        # TODO: Is the encoding properly handled or do we have to consider our options?
+        self.wfile.write(json.dumps(result).encode())
+        self.end_headers()

--- a/ly/server/main.py
+++ b/ly/server/main.py
@@ -1,0 +1,153 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+The entry point for the 'ly-server' command.
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+try:
+    from http.server import HTTPServer
+except ImportError:
+    # Python 2:
+    from BaseHTTPServer import HTTPServer
+
+import copy
+import sys
+
+import ly.pkginfo
+from . import options
+from . import handler
+
+
+def usage():
+    """Print usage info."""
+    from . import doc
+    sys.stdout.write(doc.__doc__)
+
+
+def usage_short():
+    """Print short usage info."""
+    sys.stdout.write("""\
+Usage: ly-server [options]
+
+An HTTP server for manipulating LilyPond input code
+
+See ly-server -h for a full list of commands and options.
+""")
+
+
+def version():
+    """Print version info."""
+    sys.stdout.write("ly {0}\n".format(ly.pkginfo.version))
+
+
+def die(message):
+    """Exit with message to STDERR.
+    In ly-server this should only be called upon startup, not while processing
+    requests. Then the error should be sent back to the client."""
+    sys.stderr.write("error: " + message + '\n')
+    sys.stderr.write(
+        "See ly-server -h for a full list of commands and options.\n")
+    sys.exit(1)
+
+
+def parse_command_line():
+    """Returns a two-tuple(server_opts, cmd_opts)
+    
+    server_opts is a ServerOptions instance configuring the server behaviour
+    cmd_opts is an Options instance with default options for future command
+    executions triggered by HTTP requests.
+    
+    Also performs error handling and may exit on certain circumstances.
+    
+    """
+    
+    if isinstance(sys.argv[0], type('')):
+        # python 3 - arguments are unicode strings
+        args = iter(sys.argv[1:])
+    else:
+        # python 2 - arguments are bytes, decode them
+        fsenc = sys.getfilesystemencoding() or 'latin1'
+        args = (a.decode(fsenc) for a in sys.argv[1:])
+    
+    server_opts = options.ServerOptions()
+    cmd_opts = options.Options()
+    
+    def next_arg(message):
+        """Get the next argument, if missing, die with message."""
+        try:
+            return next(args)
+        except StopIteration:
+            die(message)
+    
+    for arg in args:
+        if arg in ('-h', '--help'):
+            usage()
+            sys.exit(0)
+        elif arg in ('-v', '--version'):
+            version()
+            sys.exit(0)
+        
+        # Server Options
+        elif arg in ('-p', '--port'):
+            server_opts.port = int(next_arg("missing port number"))
+        elif arg in ('-t', '--timeout'):
+            server_opts.timeout = int(next_arg("missing timeout (in ms)"))
+            
+        # Command Options
+        elif arg in ('-e', '--encoding'):
+            cmd_opts.encoding = next_arg("missing encoding name")
+        elif arg == '--output-encoding':
+            cmd_opts.output_encoding = next_arg("missing output encoding name")
+        elif arg in ('-l', '--language'):
+            s = next_arg("missing language name")
+            cmd_opts.set_variable("default-language", s)
+        
+        # Command configuration Variables
+        elif arg == '-d':
+            s = next_arg("missing variable=value")
+            try:
+                name, value = s.split('=', 1)
+            except ValueError:
+                die("missing '=' in variable set")
+            cmd_opts.set_variable(name, value)
+        
+        elif arg.startswith('-'):
+            die('unknown option: ' + arg)
+    
+    return server_opts, cmd_opts
+
+
+def main():
+    server_opts, cmd_opts = parse_command_line()
+    handler.default_opts = copy.deepcopy(cmd_opts)
+    exit_code = 0
+    try:
+        server = HTTPServer(('', server_opts.port), handler.RequestHandler)
+        print("Welcome to the python-ly HTTP server")
+        print("Listening on port {port}".format(port=server_opts.port))
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nKeyboard interrupt received. Shutting down server")
+        server.socket.close()
+        print("Successfully closed. Bye...")
+    return exit_code

--- a/ly/server/options.py
+++ b/ly/server/options.py
@@ -1,0 +1,74 @@
+# This file is part of python-ly, https://pypi.python.org/pypi/python-ly
+#
+# Copyright (c) 2014 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Options configuring the commands' behaviour
+"""
+
+from __future__ import unicode_literals
+
+from ly.cli import setvar
+
+class ServerOptions(object):
+    """
+    Options configuring the server itself, not the individual commands
+    """
+    
+    def __init__(self):
+        self.port = 5432
+        self.timeout = 0
+    
+
+class Options(object):
+    """Store all the startup options and their defaults."""
+    def __init__(self):
+        self.mode = None
+        self.in_place = False
+        self.encoding = 'UTF-8'
+        self.output_encoding = None
+        self.output = None
+        self.replace_pattern = True
+        self.backup_suffix = '~'
+        self.with_filename = None
+        self.default_language = "nederlands"
+        
+        self.indent_width = 2
+        self.indent_tabs = False
+        self.tab_width = 8
+        
+        self.full_html = True
+        self.inline_style = False
+        self.stylesheet = None
+        self.number_lines = False
+        self.wrapper_tag = 'pre'
+        self.wrapper_attribute = 'class'
+        self.document_id = 'lilypond'
+        self.linenumbers_id = 'linenumbers'
+
+    def set_variable(self, name, value):
+        name = name.replace('-', '_')
+        try:
+            func = getattr(setvar, name)
+        except AttributeError:
+            raise AttributeError("unknown variable: {name}".format(name=name))
+        try:
+            value = func(value)
+        except ValueError as e:
+            raise ValueError(format(e))
+        setattr(self, name, value)    

--- a/ly/server/testjson.py
+++ b/ly/server/testjson.py
@@ -1,0 +1,24 @@
+# test dataset for simpler handling of JSON request during testing phase
+
+test_request = {
+    'commands': [
+        {
+            'command': 'transpose',
+            'args': 'c d'
+        },
+        { 'command': 'reformat' },
+        {
+            'command': 'highlight',
+            'variables': { 'full-html': 'false' }
+        },
+        { 'command': 'musicxml' },
+        { 'command': 'mode' },
+        { 'command': 'version' }
+    ],
+    'options': {
+        'encoding': 'UTF-16',
+        'language': "deutsch"
+    },
+    'data': "%No JSON data supplied. This is a test request.\n" +
+            "\\relative c' {\nc4 ( d e )\n}"
+}


### PR DESCRIPTION
Addresses #60

In its first version this server supports POST requests that trigger the ly commands just like the ly CLI script does.

The new version leaves `ly.cli` completely alone and just uses `ly.cli.setvar`. Everything else is implemented from copies of the `ly.cli` code.

For the creation of commands I have implemented a whitelist in order to prevent arbitrary "attributes" to be called.

To be done:
- Encoding problem with Python2/3 (see `command.musicxml`)
- Disambiguation of error reporting
- implementing the --timeout option (automatic shutdown)
- Add some GET routes for more interesting behaviour
  - /version (return ly version)
  - /stop (stop the server)
  - /timeout/N (modify the timeout)
  - etc?