### PR TITLE
strip() variables in command string

### DIFF
--- a/ly/cli/main.py
+++ b/ly/cli/main.py
@@ -244,7 +244,7 @@ def parse_command(arg):
         args = c.split(None, 1)
         if args:
             if '=' in args[0]:
-                args = ['set_variable', c]
+                args = ['set_variable', c.strip()]
             cmd = args.pop(0)
             try:
                 result.append(getattr(command, cmd.replace('-', '_'))(*args))


### PR DESCRIPTION
When setting a variable in the command string it produced an
"unknown variable" error when the variable name didn't start immediately after the semicolon. This was because the "sanitizing" applied by the
split() operation wasn't applied when directly referencing `c`.