### PR TITLE
MusicXML export: Insert check against empty "sections" list

### DIFF
--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -290,7 +290,10 @@ class Mediator():
             self.part.merge_voice(self.sections[-1])
         elif len(self.sections)>1:
              self.sections[-2].merge_voice(self.sections[-1])
-        self.sections.pop()
+
+        print("\n\nAchtung, sections: {}\n\n".format(self.sections))
+        if (len(self.sections) > 0):
+            self.sections.pop()
 
     def check_score(self):
         """


### PR DESCRIPTION
I don't know what this code actually is about, but adding this
check made a file compile that before caused a traceback because of
trying to pop from an empty list.

@PeterBjuhr Please have a look into this and tell me if I'm curing the right symptoms with that.
Actually I don't have any clue what this `sections` object is for.

Addresses #76 