### PR TITLE
MusicXML: Recognise \breathe

### DIFF
--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -983,7 +983,8 @@ def artic_token2xml_name(art_token):
     artic_dict = {
     ".": "staccato", "-": "tenuto", ">": "accent",
     "_": "detached-legato", "!": "staccatissimo",
-    "\\staccatissimo": "staccatissimo"
+    "\\staccatissimo": "staccatissimo",
+    "\\breathe": "breath-mark"
     }
     ornaments = ['\\trill', '\\prall', '\\mordent', '\\turn']
     others = ['\\fermata']

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -497,6 +497,8 @@ class ParseSource():
             if self.tupl_span:
                 self.mediator.unset_tuplspan_dur()
                 self.tupl_span = False
+        elif command.token == '\\breathe':
+            self.mediator.new_articulation(command.token)
         else:
             if command.token not in excls:
                 print("Unknown command:", command.token)


### PR DESCRIPTION
Add breathe as a articulation element,
according to
https://usermanuals.musicxml.com/MusicXML/Content/EL-MusicXML-breath-mark.htm