### PR TITLE
MusicXML: tempo number should be integer

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -614,6 +614,7 @@ class CreateMusicXML():
         pmnode.text = str(beats)
 
     def add_sound_dir(self, midi_tempo):
+        # FIXME: remove the int conversion once LilyPond accepts decimal tempo
         soundnode = etree.SubElement(self.direction, "sound", tempo=str(int(midi_tempo)))
 
     def add_lyric(self, txt, syll, nr, ext=False):

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -614,7 +614,7 @@ class CreateMusicXML():
         pmnode.text = str(beats)
 
     def add_sound_dir(self, midi_tempo):
-        soundnode = etree.SubElement(self.direction, "sound", tempo=str(midi_tempo))
+        soundnode = etree.SubElement(self.direction, "sound", tempo=str(int(midi_tempo)))
 
     def add_lyric(self, txt, syll, nr, ext=False):
         """ Add lyric element. """


### PR DESCRIPTION
A simple fix to a crash in lilypond (python-ly -> convert-ly ->
lilypond) due to tempo being exported as a float.