### PR TITLE
MusicXML: recognize \partial

### DIFF
--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -331,6 +331,12 @@ class ParseSource():
 
     def Duration(self, duration):
         """A written duration"""
+
+        if isinstance(duration.parent(), ly.music.items.Partial):
+            # No need to handle the duration element for a \partial element
+            # unless barcheck should be implemented
+            return
+
         if self.tempo:
             self.mediator.new_tempo(duration.token, duration.tokens, *self.tempo)
             self.tempo = ()
@@ -549,6 +555,10 @@ class ParseSource():
     def LyricMode(self, lyricmode):
         r"""A \lyricmode, \lyrics or \addlyrics expression."""
         self.alt_mode = 'lyric'
+
+    def Partial(self, partial):
+        r"""A \partial node"""
+        pass
 
     def Override(self, override):
         r"""An \override command."""

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -31,6 +31,10 @@ def test_tuplet():
     compare_output('tuplet')
 
 
+def test_partial():
+    compare_output('partial')
+
+
 def ly_to_xml(filename):
     """Read Lilypond file and return XML string."""
     writer = ly.musicxml.writer()

--- a/tests/test_xml_files/partial.ly
+++ b/tests/test_xml_files/partial.ly
@@ -1,0 +1,6 @@
+\score {
+  \relative c' {
+    \partial 4 c8 c | d1 |
+  }
+  \layout{}
+}

--- a/tests/test_xml_files/partial.xml
+++ b/tests/test_xml_files/partial.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <identification>
+    <encoding>
+      <software>python-ly 0.9.5</software>
+      <encoding-date>2017-04-07</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name />
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="3" />
+  </part>
+</score-partwise>


### PR DESCRIPTION
An attempt to avoid python-ly's musicXML export choke on the partial node and it's duration