### PR TITLE
MusicXML: \markup export

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -598,7 +598,7 @@ class CreateMusicXML():
 
     def add_dirwords(self, words):
         """Add words in direction, e. g. a tempo mark."""
-        if not hasattr(self,'direction'):
+        if self.current_bar.find('direction') == None:
             self.add_direction()
         dirtypenode = etree.SubElement(self.direction, "direction-type")
         wordsnode = etree.SubElement(dirtypenode, "words")

--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -598,6 +598,8 @@ class CreateMusicXML():
 
     def add_dirwords(self, words):
         """Add words in direction, e. g. a tempo mark."""
+        if not hasattr(self,'direction'):
+            self.add_direction()
         dirtypenode = etree.SubElement(self.direction, "direction-type")
         wordsnode = etree.SubElement(dirtypenode, "words")
         wordsnode.text = words

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -76,6 +76,7 @@ class Mediator():
         self.prev_tremolo = 8
         self.tupl_dur = 0
         self.tupl_sum = 0
+        self.word = None
 
     def new_header_assignment(self, name, value):
         """Distributing header information."""
@@ -345,6 +346,16 @@ class Mediator():
             self.add_to_bar(new_bar_attr)
         else:
             self.current_attr.set_key(get_fifths(key_name, mode), mode)
+
+    def new_word(self, word):
+        if self.bar is None:
+            self.new_bar()
+        if self.bar.has_music():
+            new_bar_attr = xml_objs.BarAttr()
+            new_bar_attr.set_word(word)
+            self.add_to_bar(new_bar_attr)
+        else:
+            self.current_attr.set_word(word)
 
     def new_time(self, num, den, numeric=False):
         if self.bar is None:

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -77,7 +77,6 @@ class Mediator():
         self.prev_tremolo = 8
         self.tupl_dur = 0
         self.tupl_sum = 0
-        self.word = None
         self.bar_is_pickup = False
         self.stem_dir = None
 

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -350,12 +350,12 @@ class Mediator():
     def new_word(self, word):
         if self.bar is None:
             self.new_bar()
-        if self.bar.has_music():
+        if self.bar.has_attr():
+            self.current_attr.set_word(word)
+        else:
             new_bar_attr = xml_objs.BarAttr()
             new_bar_attr.set_word(word)
             self.add_to_bar(new_bar_attr)
-        else:
-            self.current_attr.set_word(word)
 
     def new_time(self, num, den, numeric=False):
         if self.bar is None:

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -512,6 +512,9 @@ class ParseSource():
     def MarkupWord(self, markupWord):
         self.mediator.new_word(markupWord.token)
 
+    def MarkupList(self, markuplist):
+        pass
+
     def String(self, string):
         prev = self.get_previous_node(string)
         if prev and prev.token == '\\bar':

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -506,6 +506,12 @@ class ParseSource():
         if usercommand.name() == 'tupletSpan':
             self.tupl_span = True
 
+    def Markup(self, markup):
+        pass
+
+    def MarkupWord(self, markupWord):
+        self.mediator.new_word(markupWord.token)
+
     def String(self, string):
         prev = self.get_previous_node(string)
         if prev and prev.token == '\\bar':

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -449,6 +449,13 @@ class Bar():
                 return True
         return False
 
+    def has_attr(self):
+         """ Check if bar contains attribute. """
+         for obj in self.obj_list:
+             if isinstance(obj, BarAttr):
+                 return True
+         return False
+
     def create_backup(self):
         """ Calculate and create backup object."""
         b = 0
@@ -754,7 +761,7 @@ class BarAttr():
     def set_word(self, words):
         if self.word == None:
             self.word = ''
-        self.word += words
+        self.word += words + ' '
 
     def has_attr(self):
         check = False

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -134,6 +134,8 @@ class IterateXmlObjs():
         if obj.tempo:
             self.musxml.create_tempo(obj.tempo.text, obj.tempo.metr,
                                      obj.tempo.midi, obj.tempo.dots)
+        if obj.word:
+            self.musxml.add_dirwords(obj.word)
 
     def before_note(self, obj):
         """Xml-nodes before note."""
@@ -726,6 +728,7 @@ class BarAttr():
         self.staves = 0
         self.multiclef = []
         self.tempo = None
+        self.word = None
 
     def __repr__(self):
         return '<{0} {1}>'.format(self.__class__.__name__, self.time)
@@ -747,6 +750,11 @@ class BarAttr():
 
     def set_tempo(self, unit=0, unittype='', beats=0, dots=0, text=""):
         self.tempo = TempoDir(unit, unittype, beats, dots, text)
+
+    def set_word(self, words):
+        if self.word == None:
+            self.word = ''
+        self.word += words
 
     def has_attr(self):
         check = False

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -31,6 +31,10 @@ def test_tuplet():
     compare_output('tuplet')
 
 
+def test_markup():
+    compare_output('markup')
+
+
 def ly_to_xml(filename):
     """Read Lilypond file and return XML string."""
     writer = ly.musicxml.writer()

--- a/tests/test_xml_files/markup.ly
+++ b/tests/test_xml_files/markup.ly
@@ -3,6 +3,7 @@
 \score {
   \relative {
     a'1-\markup intenso |
-    a'1-\markup intenso
+    a'1-\markup intenso |
+    a2^\markup { poco \italic piu forte  }
   }
 }

--- a/tests/test_xml_files/markup.ly
+++ b/tests/test_xml_files/markup.ly
@@ -2,12 +2,7 @@
 
 \score {
   \relative {
+    a'1-\markup intenso |
     a'1-\markup intenso
-%    a2^\markup { poco \italic più forte  }
-%    c e1
-%    d2_\markup { \italic "string. assai" }
-%    e
-%    b1^\markup { \bold { molto \italic  agitato } }
-%    c
   }
 }

--- a/tests/test_xml_files/markup.ly
+++ b/tests/test_xml_files/markup.ly
@@ -1,0 +1,13 @@
+\version "2.18.2"
+
+\score {
+  \relative {
+    a'1-\markup intenso
+%    a2^\markup { poco \italic più forte  }
+%    c e1
+%    d2_\markup { \italic "string. assai" }
+%    e
+%    b1^\markup { \bold { molto \italic  agitato } }
+%    c
+  }
+}

--- a/tests/test_xml_files/markup.ly
+++ b/tests/test_xml_files/markup.ly
@@ -3,7 +3,7 @@
 \score {
   \relative {
     a'1-\markup intenso |
-    a'1-\markup intenso |
-    a2^\markup { poco \italic piu forte  }
+    a1-\markup intenso |
+    a2^\markup { poco più forte  }
   }
 }

--- a/tests/test_xml_files/markup.xml
+++ b/tests/test_xml_files/markup.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <identification>
+    <encoding>
+      <software>python-ly 0.9.5</software>
+      <encoding-date>2017-06-30</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name />
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words>intenso </words>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <direction placement="above">
+        <direction-type>
+          <words>intenso </words>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="3">
+      <direction placement="above">
+        <direction-type>
+          <words>poco più forte </words>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
It is still a work in progress. Right now it only works with a single word after \markup, as in the markup.ly test file.