### PR TITLE
MusicXML: \mark export

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -602,6 +602,14 @@ class CreateMusicXML():
         wordsnode = etree.SubElement(dirtypenode, "words")
         wordsnode.text = words
 
+    def add_mark(self, mark):
+        """Add rehearsal mark in direction"""
+        if self.current_bar.find('direction') == None:
+            self.add_direction()
+        dirtypenode = etree.SubElement(self.direction, "direction-type")
+        rehearsalnode = etree.SubElement(dirtypenode, "rehearsal")
+        rehearsalnode.text = mark
+
     def add_metron_dir(self, unit, beats, dots):
         dirtypenode = etree.SubElement(self.direction, "direction-type")
         metrnode = etree.SubElement(dirtypenode, "metronome")

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -76,7 +76,7 @@ class Mediator():
         self.prev_tremolo = 8
         self.tupl_dur = 0
         self.tupl_sum = 0
-        self.current_mark = 'A'
+        self.current_mark = 1
         self.bar_is_pickup = False
 
     def new_header_assignment(self, name, value):
@@ -370,16 +370,32 @@ class Mediator():
             new_s += 'A' * num_replacements
         return new_s
 
-    def new_mark(self):
-        if self.bar is None:
-            self.new_bar()
-        if self.bar.has_music():
-            new_bar_attr = xml_objs.BarAttr()
-            new_bar_attr.set_mark(self.current_mark)
-            self.add_to_bar(new_bar_attr)
+    def bijective(self, n):
+        '''encodes an int to a sequence of letters'''
+        import string
+        digits = string.ascii_uppercase.replace("I","")
+        result = []
+        while n > 0:
+            n, mod = divmod(n - 1, len(digits))
+            result += digits[mod]
+        return ''.join(reversed(result))
+
+    def new_mark(self, num_mark = None):
+        if num_mark == None:
+            if self.bar is None:
+                self.new_bar()
+            if self.bar.has_attr():
+                self.current_attr.set_mark(self.bijective(self.current_mark))
+            else:
+                new_bar_attr = xml_objs.BarAttr()
+                new_bar_attr.set_mark(self.bijective(self.current_mark))
+                self.add_to_bar(new_bar_attr)
+        elif num_mark <= 0:
+            print("Mark value out of range")
         else:
-            self.current_attr.set_mark(self.current_mark)
-        self.current_mark = self.increment_str(self.current_mark)
+            self.current_mark = num_mark
+            self.current_attr.set_mark(self.bijective(self.current_mark))
+        self.current_mark += 1
 
     def new_time(self, num, den, numeric=False):
         if self.bar is None:

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -354,22 +354,6 @@ class Mediator():
         else:
             self.current_attr.set_key(get_fifths(key_name, mode), mode)
 
-    def increment_str(self, s):
-        l = s.rstrip('Z')
-        num_replacements = len(s) - len(l)
-        new_s = l[:-1]
-        if not l:  # s contains only 'Z'
-            new_s = 'A' * (len(s) + 1)
-        else:
-            c = l[-1]
-            num_replacements = len(s) - len(l)
-            if c == 'H':
-                new_s = l[:-1] + chr(ord(c) + 2)
-            else:
-                new_s = l[:-1] + chr(ord(c) + 1) if c != 'Z' else 'A'
-            new_s += 'A' * num_replacements
-        return new_s
-
     def bijective(self, n):
         '''encodes an int to a sequence of letters'''
         import string

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -76,6 +76,7 @@ class Mediator():
         self.prev_tremolo = 8
         self.tupl_dur = 0
         self.tupl_sum = 0
+        self.current_mark = 'A'
 
     def new_header_assignment(self, name, value):
         """Distributing header information."""
@@ -345,6 +346,17 @@ class Mediator():
             self.add_to_bar(new_bar_attr)
         else:
             self.current_attr.set_key(get_fifths(key_name, mode), mode)
+
+    def new_mark(self):
+        if self.bar is None:
+            self.new_bar()
+        if self.bar.has_music():
+            new_bar_attr = xml_objs.BarAttr()
+            new_bar_attr.set_mark(self.current_mark)
+            self.add_to_bar(new_bar_attr)
+        else:
+            self.current_attr.set_mark(self.current_mark)
+        self.current_mark = chr(ord(self.current_mark) + 1)
 
     def new_time(self, num, den, numeric=False):
         if self.bar is None:

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -354,6 +354,22 @@ class Mediator():
         else:
             self.current_attr.set_key(get_fifths(key_name, mode), mode)
 
+    def increment_str(self, s):
+        l = s.rstrip('Z')
+        num_replacements = len(s) - len(l)
+        new_s = l[:-1]
+        if not l:  # s contains only 'Z'
+            new_s = 'A' * (len(s) + 1)
+        else:
+            c = l[-1]
+            num_replacements = len(s) - len(l)
+            if c == 'H':
+                new_s = l[:-1] + chr(ord(c) + 2)
+            else:
+                new_s = l[:-1] + chr(ord(c) + 1) if c != 'Z' else 'A'
+            new_s += 'A' * num_replacements
+        return new_s
+
     def new_mark(self):
         if self.bar is None:
             self.new_bar()
@@ -363,7 +379,7 @@ class Mediator():
             self.add_to_bar(new_bar_attr)
         else:
             self.current_attr.set_mark(self.current_mark)
-        self.current_mark = chr(ord(self.current_mark) + 1)
+        self.current_mark = self.increment_str(self.current_mark)
 
     def new_time(self, num, den, numeric=False):
         if self.bar is None:

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -584,6 +584,8 @@ class ParseSource():
             self.override_dict[self.override_key] = item.token
         elif self.schm_assignm:
             self.mediator.set_by_property(self.schm_assignm, item.token)
+        elif self.mark:
+            self.mediator.new_mark(int(item.token))
         else:
             print("SchemeItem not implemented:", item.token)
 

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -89,6 +89,7 @@ class ParseSource():
         self.slurcount = 0
         self.slurnr = 0
         self.phrslurnr = 0
+        self.mark = False
 
     def parse_text(self, ly_text, filename=None):
         """Parse the LilyPond source specified as text.
@@ -493,10 +494,15 @@ class ParseSource():
             self.mediator.new_trill_spanner("stop")
         elif command.token == '\\ottava':
             self.ottava = True
+        elif command.token == '\\mark':
+            self.mark = True
+            self.mediator.new_mark()
         elif command.token == '\\default':
             if self.tupl_span:
                 self.mediator.unset_tuplspan_dur()
                 self.tupl_span = False
+            elif self.mark:
+                self.mark = False
         else:
             if command.token not in excls:
                 print("Unknown command:", command.token)

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -134,6 +134,8 @@ class IterateXmlObjs():
         if obj.tempo:
             self.musxml.create_tempo(obj.tempo.text, obj.tempo.metr,
                                      obj.tempo.midi, obj.tempo.dots)
+        if obj.mark:
+            self.musxml.add_mark(obj.mark)
 
     def before_note(self, obj):
         """Xml-nodes before note."""
@@ -726,6 +728,7 @@ class BarAttr():
         self.staves = 0
         self.multiclef = []
         self.tempo = None
+        self.mark = None
 
     def __repr__(self):
         return '<{0} {1}>'.format(self.__class__.__name__, self.time)
@@ -747,6 +750,9 @@ class BarAttr():
 
     def set_tempo(self, unit=0, unittype='', beats=0, dots=0, text=""):
         self.tempo = TempoDir(unit, unittype, beats, dots, text)
+
+    def set_mark(self, mark):
+        self.mark = mark
 
     def has_attr(self):
         check = False

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -455,11 +455,11 @@ class Bar():
         return False
 
     def has_attr(self):
-         """ Check if bar contains attribute. """
-         for obj in self.obj_list:
-             if isinstance(obj, BarAttr):
-                 return True
-         return False
+        """ Check if bar contains attribute. """
+        for obj in self.obj_list:
+            if isinstance(obj, BarAttr):
+                return True
+        return False
 
     def create_backup(self):
         """ Calculate and create backup object."""

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -450,6 +450,13 @@ class Bar():
                 return True
         return False
 
+    def has_attr(self):
+        """ Check if bar contains attribute. """
+        for obj in self.obj_list:
+            if isinstance(obj, BarAttr):
+                return True
+        return False
+
     def create_backup(self):
         """ Calculate and create backup object."""
         b = 0
@@ -766,6 +773,8 @@ class BarAttr():
         elif self.multiclef:
             check = True
         elif self.divs != 0:
+            check = True
+        elif self.mark != 0:
             check = True
         return check
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -31,6 +31,10 @@ def test_tuplet():
     compare_output('tuplet')
 
 
+def test_mark():
+    compare_output('mark')
+
+
 def ly_to_xml(filename):
     """Read Lilypond file and return XML string."""
     writer = ly.musicxml.writer()

--- a/tests/test_xml_files/mark.ly
+++ b/tests/test_xml_files/mark.ly
@@ -3,57 +3,11 @@
 \score {
   \relative c' {
     c1 \mark \default |
-    d1 \mark |
+    d1 \mark #8 |
     c1 \mark \default |
-    d1 \mark |
+    d1 \mark #25 |
     c1 \mark \default |
-    d1 \mark |
+    d1 \mark #50 |
     c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    d1 \mark |
-    c1 \mark \default |
-    e1
   }
 }

--- a/tests/test_xml_files/mark.ly
+++ b/tests/test_xml_files/mark.ly
@@ -1,0 +1,9 @@
+\version "2.18.2"
+
+\score {
+  \relative c' {
+    c1 \mark \default |
+    d1 \mark \default |
+    e1
+  }
+}

--- a/tests/test_xml_files/mark.ly
+++ b/tests/test_xml_files/mark.ly
@@ -4,6 +4,56 @@
   \relative c' {
     c1 \mark \default |
     d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
+    d1 \mark |
+    c1 \mark \default |
     e1
   }
 }

--- a/tests/test_xml_files/mark.ly
+++ b/tests/test_xml_files/mark.ly
@@ -3,7 +3,7 @@
 \score {
   \relative c' {
     c1 \mark \default |
-    d1 \mark \default |
+    d1 \mark |
     e1
   }
 }

--- a/tests/test_xml_files/mark.xml
+++ b/tests/test_xml_files/mark.xml
@@ -5,7 +5,7 @@
   <identification>
     <encoding>
       <software>python-ly 0.9.5</software>
-      <encoding-date>2017-06-23</encoding-date>
+      <encoding-date>2017-06-26</encoding-date>
     </encoding>
   </identification>
   <part-list>
@@ -26,166 +26,45 @@
           <line>2</line>
         </clef>
       </attributes>
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
       <direction placement="above">
         <direction-type>
           <rehearsal>A</rehearsal>
         </direction-type>
       </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
     </measure>
     <measure number="2">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>B</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="3">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>C</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="4">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>D</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="5">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>E</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="6">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>F</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="7">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>G</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="8">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>H</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="9">
       <note>
         <pitch>
-          <step>C</step>
+          <step>D</step>
           <octave>4</octave>
         </pitch>
         <duration>4</duration>
         <voice>1</voice>
         <type>whole</type>
       </note>
+    </measure>
+    <measure number="3">
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>J</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="10">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>K</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="11">
       <note>
         <pitch>
           <step>C</step>
@@ -195,237 +74,14 @@
         <voice>1</voice>
         <type>whole</type>
       </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>L</rehearsal>
-        </direction-type>
-      </direction>
     </measure>
-    <measure number="12">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>M</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="13">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>N</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="14">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>O</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="15">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>P</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="16">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>Q</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="17">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>R</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="18">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>S</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="19">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>T</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="20">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>U</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="21">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>V</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="22">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>W</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="23">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>X</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="24">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>Y</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="25">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
+    <measure number="4">
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>Z</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="26">
       <note>
         <pitch>
           <step>D</step>
@@ -435,13 +91,14 @@
         <voice>1</voice>
         <type>whole</type>
       </note>
+    </measure>
+    <measure number="5">
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>AA</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="27">
       <note>
         <pitch>
           <step>C</step>
@@ -451,381 +108,14 @@
         <voice>1</voice>
         <type>whole</type>
       </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AB</rehearsal>
-        </direction-type>
-      </direction>
     </measure>
-    <measure number="28">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AC</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="29">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AD</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="30">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AE</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="31">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AF</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="32">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AG</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="33">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AH</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="34">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AJ</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="35">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AK</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="36">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AL</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="37">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AM</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="38">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AN</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="39">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AO</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="40">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AP</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="41">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AQ</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="42">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AR</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="43">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AS</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="44">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AT</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="45">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AU</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="46">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AV</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="47">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AW</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="48">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AX</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="49">
-      <note>
-        <pitch>
-          <step>D</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>AY</rehearsal>
-        </direction-type>
-      </direction>
-    </measure>
-    <measure number="50">
-      <note>
-        <pitch>
-          <step>C</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
+    <measure number="6">
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>AZ</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="51">
       <note>
         <pitch>
           <step>D</step>
@@ -835,13 +125,14 @@
         <voice>1</voice>
         <type>whole</type>
       </note>
+    </measure>
+    <measure number="7">
+      <attributes />
       <direction placement="above">
         <direction-type>
           <rehearsal>BA</rehearsal>
         </direction-type>
       </direction>
-    </measure>
-    <measure number="52">
       <note>
         <pitch>
           <step>C</step>
@@ -851,22 +142,9 @@
         <voice>1</voice>
         <type>whole</type>
       </note>
-      <direction placement="above">
-        <direction-type>
-          <rehearsal>BB</rehearsal>
-        </direction-type>
-      </direction>
     </measure>
-    <measure number="53">
-      <note>
-        <pitch>
-          <step>E</step>
-          <octave>4</octave>
-        </pitch>
-        <duration>4</duration>
-        <voice>1</voice>
-        <type>whole</type>
-      </note>
+    <measure number="8">
+      <attributes />
     </measure>
   </part>
 </score-partwise>

--- a/tests/test_xml_files/mark.xml
+++ b/tests/test_xml_files/mark.xml
@@ -5,7 +5,7 @@
   <identification>
     <encoding>
       <software>python-ly 0.9.5</software>
-      <encoding-date>2017-06-15</encoding-date>
+      <encoding-date>2017-06-23</encoding-date>
     </encoding>
   </identification>
   <part-list>
@@ -58,6 +58,806 @@
       </direction>
     </measure>
     <measure number="3">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>C</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>D</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="5">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>E</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="6">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>F</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="7">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>G</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="8">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>H</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="9">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>J</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="10">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>K</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="11">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>L</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="12">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>M</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="13">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>N</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="14">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>O</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="15">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>P</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="16">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>Q</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="17">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>R</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="18">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>S</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="19">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>T</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="20">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>U</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="21">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>V</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="22">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>W</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="23">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>X</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="24">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>Y</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="25">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>Z</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="26">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AA</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="27">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AB</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="28">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AC</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="29">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AD</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="30">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AE</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="31">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AF</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="32">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AG</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="33">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AH</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="34">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AJ</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="35">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AK</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="36">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AL</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="37">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AM</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="38">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AN</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="39">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AO</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="40">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AP</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="41">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AQ</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="42">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AR</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="43">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AS</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="44">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AT</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="45">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AU</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="46">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AV</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="47">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AW</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="48">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AX</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="49">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AY</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="50">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>AZ</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="51">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>BA</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="52">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>BB</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="53">
       <note>
         <pitch>
           <step>E</step>

--- a/tests/test_xml_files/mark.xml
+++ b/tests/test_xml_files/mark.xml
@@ -5,7 +5,7 @@
   <identification>
     <encoding>
       <software>python-ly 0.9.5</software>
-      <encoding-date>2017-06-11</encoding-date>
+      <encoding-date>2017-06-15</encoding-date>
     </encoding>
   </identification>
   <part-list>

--- a/tests/test_xml_files/mark.xml
+++ b/tests/test_xml_files/mark.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <identification>
+    <encoding>
+      <software>python-ly 0.9.5</software>
+      <encoding-date>2017-06-11</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name />
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>A</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal>B</rehearsal>
+        </direction-type>
+      </direction>
+    </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
First attempt to support \mark feature.
By now it is only able to export the following syntax: '\mark \ default' and '\mark' and add marks from 'A' to 'Z'.