### PR TITLE
MusicXML: Fix barcheck need

### DIFF
--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -48,6 +48,7 @@ class Mediator():
         self.current_lynote = None
         self.current_is_rest = False
         self.current_time = Fraction(4, 4)
+        self.bar_dura = Fraction(0, 4)
         self.action_onnext = []
         self.divisions = 1
         self.dur_token = "4"
@@ -307,8 +308,6 @@ class Mediator():
             self.new_part()
             self.part.barlist.extend(self.get_first_var())
         self.score.merge_globally(self.score.glob_section, override=True)
-        for p in self.score.partlist:
-            p.restructure_bars()
 
     def get_first_var(self):
         if self.sections:
@@ -380,6 +379,12 @@ class Mediator():
     def set_relative(self, note):
         self.prev_pitch = note.pitch
 
+    def increase_bar_dura(self, duration):
+        self.bar_dura += duration[0] * duration[1]
+        if self.bar_dura >= self.current_time:
+            self.bar_dura = 0
+            self.new_bar()
+
     def new_note(self, note, rel=False, is_unpitched=False):
         self.current_is_rest = False
         self.clear_chord()
@@ -394,6 +399,7 @@ class Mediator():
             self.current_note.set_stem_direction(self.stem_dir)
         self.do_action_onnext(self.current_note)
         self.action_onnext = []
+        self.increase_bar_dura(note.duration)
 
     def new_iso_dura(self, note, rel=False, is_unpitched=False):
         """
@@ -575,6 +581,7 @@ class Mediator():
         elif rtype == 's' or rtype == '\\skip':
             self.current_note = xml_objs.BarRest(dur, self.voice, skip=True)
         self.check_current_note(rest=True)
+        self.increase_bar_dura(dur)
 
     def note2rest(self):
         """Note used as rest position transformed to rest."""

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -347,6 +347,7 @@ class ScoreSection():
                             obj.add_lyric(l)
                         i += 1
 
+
 class Snippet(ScoreSection):
     """ Short section intended to be merged.
     Holds reference to the barlist to be merged into."""

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -93,10 +93,14 @@ class IterateXmlObjs():
     def iterate_part(self, part):
         """The part is iterated."""
         if part.barlist:
+            last_bar = part.barlist[-1]
+            last_bar_objs = last_bar.obj_list
             part.set_first_bar(self.divisions)
             self.musxml.create_part(part.name, part.abbr, part.midi)
-            for bar in part.barlist:
+            for bar in part.barlist[:-1]:
                 self.iterate_bar(bar)
+            if len(last_bar_objs) > 1 or last_bar_objs[0].has_attr():
+                self.iterate_bar(last_bar)
         else:
             print("Warning: empty part:", part.name)
 

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -336,32 +336,6 @@ class ScoreSection():
                             obj.add_lyric(l)
                         i += 1
 
-    def restructure_bars(self):
-        """Recount and restructure the bars in the section.
-        Should only be done if you are sure the bar information
-        given is inadequate.
-        """
-        time = Fraction(4, 4)
-        dura = 0
-        bl = []
-        for bar in self.barlist:
-            nb = Bar()
-            for obj in bar.obj_list:
-                if isinstance(obj, BarAttr):
-                    if obj.time:
-                        time = Fraction(obj.time[0], obj.time[1])
-                elif isinstance(obj, BarMus):
-                    dura += obj.duration[0] * obj.duration[1]
-                    if dura >= time:
-                        dura = 0
-                        nb.obj_list.append(obj)
-                        bl.append(nb)
-                        nb = Bar()
-                        continue
-                nb.obj_list.append(obj)
-        self.barlist = bl
-
-
 class Snippet(ScoreSection):
     """ Short section intended to be merged.
     Holds reference to the barlist to be merged into."""

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -39,6 +39,10 @@ def test_stem_direction():
     compare_output('stem')
 
 
+def test_no_barcheck():
+    compare_output('no_barcheck')
+
+
 def ly_to_xml(filename):
     """Read Lilypond file and return XML string."""
     writer = ly.musicxml.writer()

--- a/tests/test_xml_files/no_barcheck.ly
+++ b/tests/test_xml_files/no_barcheck.ly
@@ -1,0 +1,12 @@
+\version "2.18.2"
+
+\score {
+  \relative c'{ 
+    c4 d2 r4 
+    d1
+    f2. d4
+    \time 2/4 c2
+    \time 4/4 c1
+  }
+  \layout {}
+}

--- a/tests/test_xml_files/no_barcheck.xml
+++ b/tests/test_xml_files/no_barcheck.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <identification>
+    <encoding>
+      <software>python-ly 0.9.5</software>
+      <encoding-date>2017-08-01</encoding-date>
+    </encoding>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name />
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+      <note>
+        <rest />
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot />
+      </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <measure number="4">
+      <attributes>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <measure number="5">
+      <attributes>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <measure number="6" />
+  </part>
+</score-partwise>

--- a/tests/test_xml_files/no_barcheck.xml
+++ b/tests/test_xml_files/no_barcheck.xml
@@ -5,7 +5,7 @@
   <identification>
     <encoding>
       <software>python-ly 0.9.5</software>
-      <encoding-date>2017-08-01</encoding-date>
+      <encoding-date>2017-08-08</encoding-date>
     </encoding>
   </identification>
   <part-list>
@@ -117,6 +117,5 @@
         <type>whole</type>
       </note>
     </measure>
-    <measure number="6" />
   </part>
 </score-partwise>


### PR DESCRIPTION
Solution to export measures without the help of explicit barchecks `|`.
The @PeterBjuhr solution gave me a good idea about how to do this, but it fails when time signature changes along the score.
To do so I chose to 'create' the measures inside the mediator instead of inside `xml_objs.py`

It has to be refined yet, mainly because it always leave a blank measure at the end of the score.