### PR TITLE
MusicXML export: Properly handle tagline and copyright

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -273,9 +273,10 @@ class CreateMusicXML():
         attr = {'type': creator }
         self.create_score_info("creator", name, attr)
 
-    def add_rights(self, rights):
+    def add_rights(self, rights, type=None):
         """Add rights to score info."""
-        self.create_score_info("rights", rights)
+        attr = {'type': type} if type else {}
+        self.create_score_info("rights", rights, attr)
 
     def create_note(self):
         """Create new note."""

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -89,8 +89,8 @@ class Mediator():
         creators = ['composer', 'arranger', 'poet', 'lyricist']
         if name == 'title':
             self.score.title = value
-        elif name == 'copyright':
-            self.score.rights = value
+        elif name in ['copyright', 'tagline']:
+            self.score.add_right(value, name)
         elif name in creators:
             self.score.creators[name] = value
         else:

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -72,7 +72,11 @@ class IterateXmlObjs():
         for itag in score.info:
             self.musxml.create_score_info(itag, score.info[itag])
         if score.rights:
-            self.musxml.add_rights(score.rights)
+            if len(score.rights) > 1:
+                for right in score.rights:
+                    self.musxml.add_rights(right[0], right[1])
+            else:
+                self.musxml.add_rights(score.rights[0][0])
         for p in score.partlist:
             if isinstance(p, ScorePart):
                 self.iterate_part(p)
@@ -238,8 +242,11 @@ class Score():
         self.title = None
         self.creators = {}
         self.info = {}
-        self.rights = None
+        self.rights = []
         self.glob_section = ScoreSection('global', True)
+
+    def add_right(self, value, type):
+        self.rights.append((value, type))
 
     def is_empty(self):
         """Check if score is empty."""


### PR DESCRIPTION
Any tagline (including `""` and `##f`) has been exported to a <tagline />
tag within `<identification>`. This is invalid MusicXML, and I think it should be generally reconsidered to simply pump unrecognized header items to
score.info[name].

For "tagline" this commit fixes the behaviour by treating a tagline as a
"rights" tag.
According to the specification one or multiple rights tags can be present,
and if more than one is present each must have an (arbitrary) attribute.