### PR TITLE
XML: Start supporting manual Beam (WIP)

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -366,7 +366,7 @@ class CreateMusicXML():
 
     def add_beam(self, nr, beam_type):
         """Add beam. """
-        beam_node = etree.SubElement(self.current_notation, "beam", number=str(nr))
+        beam_node = etree.SubElement(self.current_note, "beam", number=str(nr))
         beam_node.text = beam_type
 
     def add_tie(self, tie_type):

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -707,6 +707,9 @@ class Mediator():
         self.tied = True
         self.current_note.set_tie(tie_type)
 
+    def set_beam(self, nr, beam_type):
+        self.current_note.set_beam(nr, beam_type)
+        
     def set_slur(self, nr, slur_type):
         """
         Set the slur start or stop for the current note. """

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -86,6 +86,8 @@ class ParseSource():
         self.unset_tuplspan = False
         self.alt_mode = None
         self.rel_pitch_isset = False
+        self.beamcount = 0
+        self.beamnr = 0
         self.slurcount = 0
         self.slurnr = 0
         self.phrslurnr = 0
@@ -94,10 +96,10 @@ class ParseSource():
 
     def parse_text(self, ly_text, filename=None):
         """Parse the LilyPond source specified as text.
-        
+
         If you specify a filename, it can be used to resolve \\include commands
         correctly.
-        
+
         """
         doc = ly.document.Document(ly_text)
         doc.filename = filename
@@ -105,11 +107,11 @@ class ParseSource():
 
     def parse_document(self, ly_doc, relative_first_pitch_absolute=False):
         """Parse the LilyPond source specified as a ly.document document.
-        
+
         If relative_first_pitch_absolute is set to True, the first pitch in a
         \relative expression without startpitch is considered to be absolute
         (LilyPond 2.18+ behaviour).
-        
+
         """
         # The document is copied and the copy is converted to absolute mode to
         # facilitate the export. The original document is unchanged.
@@ -412,7 +414,13 @@ class ParseSource():
         pass
 
     def Beam(self, beam):
-        pass
+        if beam.token == '[':
+            self.beamcount += 1
+            self.beamnr = self.beamcount
+            self.mediator.set_beam(self.beamnr, "begin")
+        else:
+            self.mediator.set_beam(self.beamnr, "end")
+            self.beamcount -= 1
 
     def Slur(self, slur):
         """ Slur, '(' = start, ')' = stop. """

--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -195,6 +195,8 @@ class IterateXmlObjs():
             self.musxml.tie_note(t)
         for s in obj.slur:
             self.musxml.add_slur(s.nr, s.slurtype)
+        for b in obj.beam:
+            self.musxml.add_beam(b.nr, b.beam_type)
         for a in obj.artic:
             self.musxml.new_articulation(a)
         if obj.ornament:
@@ -619,6 +621,11 @@ class Slur():
         self.nr = nr
         self.slurtype = slurtype
 
+class Beam():
+    def __init__(self, nr, beam_type):
+        """Stores information about a beam."""
+        self.nr = nr
+        self.beam_type = beam_type
 
 ##
 # Subclasses of BarMus
@@ -637,6 +644,7 @@ class BarNote(BarMus):
         self.grace = (0, 0)
         self.gliss = None
         self.tremolo = ('', 0)
+        self.beam = []
         self.skip = False
         self.slur = []
         self.artic = []
@@ -645,6 +653,9 @@ class BarNote(BarMus):
         self.fingering = None
         self.lyric = None
         self.stem_direction = None
+
+    def set_beam(self, nr, beam_type):
+        self.beam.append(Beam(nr, beam_type))
 
     def set_duration(self, duration, durtype=''):
         self.duration = duration


### PR DESCRIPTION
Export "first" beam.
This works only with regular eighth note beams. Anything else won't work.
Only beam nr 1 is created and ended.
But if more than one beam is involved they have to be encoded all.

That means
a) we have to check the number of beams at [ and ]
b) we have to check at each note if it is beamed, and if so
   the current number of beams has to be calculated.
(seems challenging)