### PR TITLE
#121: XML: Properly handle \markup

### DIFF
--- a/ly/musicxml/create_musicxml.py
+++ b/ly/musicxml/create_musicxml.py
@@ -286,6 +286,21 @@ class CreateMusicXML():
         self.current_ornament = None
         self.current_tech = None
 
+    def add_markup(self, markup):
+        """ Create a new Markup element, attached to (exported before) a note"""
+        d = etree.SubElement(
+            self.current_bar,
+            'direction',
+            { 'placement': markup.direction } if markup.direction else {})
+        dt = etree.SubElement(d, 'direction-type')
+        for e in markup.elements:
+            # TODO: This loop iterates over all MarkupElement() objects,
+            # which are intended to handle different formattings.
+            # Currently there will always be only *one* such element
+            # without any explicit formatting
+            cont = etree.SubElement(dt, 'words')
+            cont.text = e.content()
+
     def add_pitch(self, step, alter, octave):
         """Create new pitch."""
         pitch = etree.SubElement(self.current_note, "pitch")

--- a/ly/musicxml/ly2xml_mediator.py
+++ b/ly/musicxml/ly2xml_mediator.py
@@ -387,14 +387,7 @@ class Mediator():
         self.current_mark += 1
 
     def new_word(self, word):
-        if self.bar is None:
-            self.new_bar()
-        if self.bar.has_attr():
-            self.current_attr.set_word(word)
-        else:
-            new_bar_attr = xml_objs.BarAttr()
-            new_bar_attr.set_word(word)
-            self.add_to_bar(new_bar_attr)
+        self.current_note.add_word(word)
 
     def new_time(self, num, den, numeric=False):
         self.current_time = Fraction(num, den.denominator)
@@ -913,6 +906,9 @@ class Mediator():
             self.lyric.append("extend")
         elif item == '\\skip':
             self.insert_into.barlist.append("skip")
+
+    def new_markup(self, direction):
+        self.current_note.add_markup(direction)
 
     def duration_from_tokens(self, tokens):
         """Calculate dots and multibar rests from tokens."""

--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -91,13 +91,14 @@ class ParseSource():
         self.phrslurnr = 0
         self.mark = False
         self.pickup = False
+        self.postfix = None
 
     def parse_text(self, ly_text, filename=None):
         """Parse the LilyPond source specified as text.
-        
+
         If you specify a filename, it can be used to resolve \\include commands
         correctly.
-        
+
         """
         doc = ly.document.Document(ly_text)
         doc.filename = filename
@@ -105,11 +106,11 @@ class ParseSource():
 
     def parse_document(self, ly_doc, relative_first_pitch_absolute=False):
         """Parse the LilyPond source specified as a ly.document document.
-        
+
         If relative_first_pitch_absolute is set to True, the first pitch in a
         \relative expression without startpitch is considered to be absolute
         (LilyPond 2.18+ behaviour).
-        
+
         """
         # The document is copied and the copy is converted to absolute mode to
         # facilitate the export. The original document is unchanged.
@@ -409,7 +410,8 @@ class ParseSource():
         self.mediator.new_articulation(art.token)
 
     def Postfix(self, postfix):
-        pass
+        op = postfix.token
+        self.postfix = 'above' if op == '^' else 'below' if op == '_' else None
 
     def Beam(self, beam):
         pass
@@ -529,6 +531,12 @@ class ParseSource():
             self.tupl_span = True
 
     def Markup(self, markup):
+        self.mediator.new_markup(self.postfix)
+
+    def MarkupCommand(self, markupCommand):
+        pass
+
+    def MarkupUserCommand(self, markupUserCommand):
         pass
 
     def MarkupWord(self, markupWord):

--- a/tests/test_xml_files/markup.ly
+++ b/tests/test_xml_files/markup.ly
@@ -2,8 +2,10 @@
 
 \score {
   \relative {
-    a'1-\markup intenso |
-    a1-\markup intenso |
-    a2^\markup { poco più forte  }
+    a'2-\markup intenso
+    a2_\markup intenso |
+    a2^\markup { poco più forte }
+    r2 |
+    r1 -\markup neutral _\markup below ^\markup above
   }
 }

--- a/tests/test_xml_files/markup.xml
+++ b/tests/test_xml_files/markup.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
                                 "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise version="3.0">
   <identification>
     <encoding>
       <software>python-ly 0.9.5</software>
-      <encoding-date>2017-06-30</encoding-date>
+      <encoding-date>2018-05-05</encoding-date>
     </encoding>
   </identification>
   <part-list>
@@ -26,11 +26,6 @@
           <line>2</line>
         </clef>
       </attributes>
-      <direction placement="above">
-        <direction-type>
-          <words>intenso </words>
-        </direction-type>
-      </direction>
       <note>
         <pitch>
           <step>A</step>
@@ -60,7 +55,7 @@
     <measure number="3">
       <direction placement="above">
         <direction-type>
-          <words>poco più forte </words>
+          <words>intenso poco più forte </words>
         </direction-type>
       </direction>
       <note>


### PR DESCRIPTION
Closes #121
As described in the Issue the previous implementation of \markup
had two flaws:
- direction modifier wasn't respected
- all markups in a bar would be added as a child of the bar
  instead of being attached to the notes

This commit creates each `\markup` as a `<direction>` element
immediately preceding the note/rest the markup is attached to.
If there's an explicit direction operator it is respected.
Multiple markups may be attached to a single note, each with its own
direction (or lack thereof).

The handling of `Markup()` and `MarkupElement()` objects is already prepared
to dealing with variable formatting, insofar as a `Markup()`
contains a list of `MarkupElement()` items, which will later be used to handle
formatting. One `\markup` will generate one `<direction>` element. This contains
a sequence of `<words>` elements (currently only one) which can individually
be assigned formatting attributes.